### PR TITLE
new view modifiers: brightness, contrast, saturation, huesaturation, colormultiply

### DIFF
--- a/Sources/SkipSwiftUI/View/AdditionalViewModifiers.swift
+++ b/Sources/SkipSwiftUI/View/AdditionalViewModifiers.swift
@@ -124,6 +124,46 @@ extension View {
 }
 
 extension View {
+    nonisolated public func brightness(_ amount: Double) -> some View {
+        return ModifierView(target: self) {
+            $0.Java_viewOrEmpty.brightness(amount)
+        }
+    }
+}
+
+extension View {
+    nonisolated public func contrast(_ amount: Double) -> some View {
+        return ModifierView(target: self) {
+            $0.Java_viewOrEmpty.contrast(amount)
+        }
+    }
+}
+
+extension View {
+    nonisolated public func saturation(_ amount: Double) -> some View {
+        return ModifierView(target: self) {
+            $0.Java_viewOrEmpty.saturation(amount)
+        }
+    }
+}
+
+extension View {
+    nonisolated public func hueRotation(_ angle: Angle) -> some View {
+        return ModifierView(target: self) {
+            $0.Java_viewOrEmpty.hueRotation(bridgedAngle: angle.radians)
+        }
+    }
+}
+
+extension View {
+    nonisolated public func colorMultiply(_ color: Color) -> some View {
+        return ModifierView(target: self) {
+            $0.Java_viewOrEmpty.colorMultiply(color.Java_view as? SkipUI.Color ?? SkipUI.Color._clear)
+        }
+    }
+}
+
+extension View {
     /* @inlinable */ nonisolated public func compositingGroup() -> some View {
         return ModifierView(target: self) {
             $0.Java_viewOrEmpty.compositingGroup()


### PR DESCRIPTION
.brightness(_:)	Adjusts the brightness of the view
.contrast(_:)	Adjusts the contrast of the view
.saturation(_:)	Adjusts the color saturation of the view
.hueRotation(_:)	Rotates the hue of the view's colors by an angle
.colorMultiply(_:)	Multiplies the view's colors by a specified color

<img width="505" height="144" alt="Screenshot 2026-01-17 at 00 07 21" src="https://github.com/user-attachments/assets/61aa8238-5640-4d95-9138-8343b1a0eaa8" />

some empty test didnt fully pass but it runs with the showcase app

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

