### PR TITLE
Bridge Stepper, DatePicker, and Slider callbacks to SkipUI

### DIFF
--- a/Sources/SkipSwiftUI/Controls/DatePicker.swift
+++ b/Sources/SkipSwiftUI/Controls/DatePicker.swift
@@ -8,6 +8,8 @@ public struct DatePicker<Label> where Label : View {
     private let selection: Binding<Date>
     private let displayedComponents: DatePicker<Label>.Components
     private let label: Label
+    private let minDate: Date?
+    private let maxDate: Date?
 
     public typealias Components = DatePickerComponents
 }
@@ -18,7 +20,13 @@ extension DatePicker : View {
 
 extension DatePicker : SkipUIBridging {
     public var Java_view: any SkipUI.View {
-        return SkipUI.DatePicker(getSelection: { selection.wrappedValue }, setSelection: { selection.wrappedValue = $0 }, bridgedDisplayedComponents: Int(displayedComponents.rawValue), bridgedLabel: label.Java_viewOrEmpty)
+        if minDate != nil || maxDate != nil {
+            let min = minDate ?? Date.distantPast
+            let max = maxDate ?? Date.distantFuture
+            return SkipUI.DatePicker(getSelection: { selection.wrappedValue }, setSelection: { selection.wrappedValue = $0 }, bridgedMinDate: min, bridgedMaxDate: max, bridgedDisplayedComponents: Int(displayedComponents.rawValue), bridgedLabel: label.Java_viewOrEmpty)
+        } else {
+            return SkipUI.DatePicker(getSelection: { selection.wrappedValue }, setSelection: { selection.wrappedValue = $0 }, bridgedDisplayedComponents: Int(displayedComponents.rawValue), bridgedLabel: label.Java_viewOrEmpty)
+        }
     }
 }
 
@@ -27,10 +35,20 @@ extension DatePicker {
         self.selection = selection
         self.displayedComponents = displayedComponents
         self.label = label()
+        self.minDate = nil
+        self.maxDate = nil
+    }
+
+    public init(selection: Binding<Date>, in range: ClosedRange<Date>, displayedComponents: DatePicker<Label>.Components = [.hourAndMinute, .date], @ViewBuilder label: () -> Label) {
+        self.selection = selection
+        self.displayedComponents = displayedComponents
+        self.label = label()
+        self.minDate = range.lowerBound
+        self.maxDate = range.upperBound
     }
 
     @available(*, unavailable)
-    public init(selection: Binding<Date>, in range: ClosedRange<Date>, displayedComponents: DatePicker<Label>.Components = [.hourAndMinute, .date], @ViewBuilder label: () -> Label) {
+    public init(selection: Binding<Date>, in range: Range<Date>, displayedComponents: DatePicker<Label>.Components = [.hourAndMinute, .date], @ViewBuilder label: () -> Label) {
         fatalError()
     }
 
@@ -50,10 +68,20 @@ extension DatePicker where Label == Text {
         self.selection = selection
         self.displayedComponents = displayedComponents
         self.label = Text(titleKey)
+        self.minDate = nil
+        self.maxDate = nil
+    }
+
+    public init(_ titleKey: LocalizedStringKey, selection: Binding<Date>, in range: ClosedRange<Date>, displayedComponents: DatePicker<Label>.Components = [.hourAndMinute, .date]) {
+        self.selection = selection
+        self.displayedComponents = displayedComponents
+        self.label = Text(titleKey)
+        self.minDate = range.lowerBound
+        self.maxDate = range.upperBound
     }
 
     @available(*, unavailable)
-    public init(_ titleKey: LocalizedStringKey, selection: Binding<Date>, in range: ClosedRange<Date>, displayedComponents: DatePicker<Label>.Components = [.hourAndMinute, .date]) {
+    public init(_ titleKey: LocalizedStringKey, selection: Binding<Date>, in range: Range<Date>, displayedComponents: DatePicker<Label>.Components = [.hourAndMinute, .date]) {
         fatalError()
     }
 
@@ -71,10 +99,20 @@ extension DatePicker where Label == Text {
         self.selection = selection
         self.displayedComponents = displayedComponents
         self.label = Text(titleResource)
+        self.minDate = nil
+        self.maxDate = nil
+    }
+
+    @_disfavoredOverload public init(_ titleResource: AndroidLocalizedStringResource, selection: Binding<Date>, in range: ClosedRange<Date>, displayedComponents: DatePicker<Label>.Components = [.hourAndMinute, .date]) {
+        self.selection = selection
+        self.displayedComponents = displayedComponents
+        self.label = Text(titleResource)
+        self.minDate = range.lowerBound
+        self.maxDate = range.upperBound
     }
 
     @available(*, unavailable)
-    @_disfavoredOverload public init(_ titleResource: AndroidLocalizedStringResource, selection: Binding<Date>, in range: ClosedRange<Date>, displayedComponents: DatePicker<Label>.Components = [.hourAndMinute, .date]) {
+    @_disfavoredOverload public init(_ titleResource: AndroidLocalizedStringResource, selection: Binding<Date>, in range: Range<Date>, displayedComponents: DatePicker<Label>.Components = [.hourAndMinute, .date]) {
         fatalError()
     }
 
@@ -92,10 +130,20 @@ extension DatePicker where Label == Text {
         self.selection = selection
         self.displayedComponents = displayedComponents
         self.label = Text(title)
+        self.minDate = nil
+        self.maxDate = nil
+    }
+
+    @_disfavoredOverload public init<S>(_ title: S, selection: Binding<Date>, in range: ClosedRange<Date>, displayedComponents: DatePicker<Label>.Components = [.hourAndMinute, .date]) where S : StringProtocol {
+        self.selection = selection
+        self.displayedComponents = displayedComponents
+        self.label = Text(title)
+        self.minDate = range.lowerBound
+        self.maxDate = range.upperBound
     }
 
     @available(*, unavailable)
-    @_disfavoredOverload public init<S>(_ title: S, selection: Binding<Date>, in range: ClosedRange<Date>, displayedComponents: DatePicker<Label>.Components = [.hourAndMinute, .date]) where S : StringProtocol {
+    @_disfavoredOverload public init<S>(_ title: S, selection: Binding<Date>, in range: Range<Date>, displayedComponents: DatePicker<Label>.Components = [.hourAndMinute, .date]) where S : StringProtocol {
         fatalError()
     }
 

--- a/Sources/SkipSwiftUI/Controls/Slider.swift
+++ b/Sources/SkipSwiftUI/Controls/Slider.swift
@@ -7,6 +7,7 @@ public struct Slider<Label, ValueLabel> where Label : View, ValueLabel : View {
     private let min: Double
     private let max: Double
     private let step: Double?
+    private let onEditingChanged: ((Bool) -> Void)?
     private let label: Label?
 }
 
@@ -16,7 +17,7 @@ extension Slider : View {
 
 extension Slider : SkipUIBridging {
     public var Java_view: any SkipUI.View {
-        return SkipUI.Slider(getValue: { value.wrappedValue }, setValue: { value.wrappedValue = $0 }, min: min, max: max, step: step, bridgedLabel: label?.Java_viewOrEmpty)
+        return SkipUI.Slider(getValue: { value.wrappedValue }, setValue: { value.wrappedValue = $0 }, min: min, max: max, step: step, bridgedOnEditingChanged: onEditingChanged, bridgedLabel: label?.Java_viewOrEmpty)
     }
 }
 
@@ -33,9 +34,13 @@ extension Slider {
 }
 
 extension Slider where ValueLabel == EmptyView {
-    @available(*, unavailable)
     public init<V>(value: Binding<V>, in bounds: ClosedRange<V> = 0...1, @ViewBuilder label: () -> Label, onEditingChanged: @escaping (Bool) -> Void) where V : BinaryFloatingPoint, V.Stride : BinaryFloatingPoint {
-        fatalError()
+        self.value = Binding(get: { Double(value.wrappedValue) }, set: { value.wrappedValue = V($0) })
+        self.min = Double(bounds.lowerBound)
+        self.max = Double(bounds.upperBound)
+        self.step = nil
+        self.onEditingChanged = onEditingChanged
+        self.label = label()
     }
 
     public init<V>(value: Binding<V>, in bounds: ClosedRange<V> = 0...1, @ViewBuilder label: () -> Label) where V : BinaryFloatingPoint, V.Stride : BinaryFloatingPoint {
@@ -43,12 +48,17 @@ extension Slider where ValueLabel == EmptyView {
         self.min = Double(bounds.lowerBound)
         self.max = Double(bounds.upperBound)
         self.step = nil
+        self.onEditingChanged = nil
         self.label = label()
     }
 
-    @available(*, unavailable)
     public init<V>(value: Binding<V>, in bounds: ClosedRange<V>, step: V.Stride = 1, @ViewBuilder label: () -> Label, onEditingChanged: @escaping (Bool) -> Void) where V : BinaryFloatingPoint, V.Stride : BinaryFloatingPoint {
-        fatalError()
+        self.value = Binding(get: { Double(value.wrappedValue) }, set: { value.wrappedValue = V($0) })
+        self.min = Double(bounds.lowerBound)
+        self.max = Double(bounds.upperBound)
+        self.step = Double(step)
+        self.onEditingChanged = onEditingChanged
+        self.label = label()
     }
 
     public init<V>(value: Binding<V>, in bounds: ClosedRange<V>, step: V.Stride = 1, @ViewBuilder label: () -> Label) where V : BinaryFloatingPoint, V.Stride : BinaryFloatingPoint {
@@ -56,14 +66,19 @@ extension Slider where ValueLabel == EmptyView {
         self.min = Double(bounds.lowerBound)
         self.max = Double(bounds.upperBound)
         self.step = Double(step)
+        self.onEditingChanged = nil
         self.label = label()
     }
 }
 
 extension Slider where Label == EmptyView, ValueLabel == EmptyView {
-    @available(*, unavailable)
     public init<V>(value: Binding<V>, in bounds: ClosedRange<V> = 0...1, onEditingChanged: @escaping (Bool) -> Void) where V : BinaryFloatingPoint, V.Stride : BinaryFloatingPoint {
-        fatalError()
+        self.value = Binding(get: { Double(value.wrappedValue) }, set: { value.wrappedValue = V($0) })
+        self.min = Double(bounds.lowerBound)
+        self.max = Double(bounds.upperBound)
+        self.step = nil
+        self.onEditingChanged = onEditingChanged
+        self.label = nil
     }
 
     public init<V>(value: Binding<V>, in bounds: ClosedRange<V> = 0...1) where V : BinaryFloatingPoint, V.Stride : BinaryFloatingPoint {
@@ -71,12 +86,17 @@ extension Slider where Label == EmptyView, ValueLabel == EmptyView {
         self.min = Double(bounds.lowerBound)
         self.max = Double(bounds.upperBound)
         self.step = nil
+        self.onEditingChanged = nil
         self.label = nil
     }
 
-    @available(*, unavailable)
     public init<V>(value: Binding<V>, in bounds: ClosedRange<V>, step: V.Stride = 1, onEditingChanged: @escaping (Bool) -> Void) where V : BinaryFloatingPoint, V.Stride : BinaryFloatingPoint {
-        fatalError()
+        self.value = Binding(get: { Double(value.wrappedValue) }, set: { value.wrappedValue = V($0) })
+        self.min = Double(bounds.lowerBound)
+        self.max = Double(bounds.upperBound)
+        self.step = Double(step)
+        self.onEditingChanged = onEditingChanged
+        self.label = nil
     }
 
     public init<V>(value: Binding<V>, in bounds: ClosedRange<V>, step: V.Stride = 1) where V : BinaryFloatingPoint, V.Stride : BinaryFloatingPoint {
@@ -84,6 +104,7 @@ extension Slider where Label == EmptyView, ValueLabel == EmptyView {
         self.min = Double(bounds.lowerBound)
         self.max = Double(bounds.upperBound)
         self.step = Double(step)
+        self.onEditingChanged = nil
         self.label = nil
     }
 }

--- a/Sources/SkipSwiftUI/Controls/Stepper.swift
+++ b/Sources/SkipSwiftUI/Controls/Stepper.swift
@@ -1,0 +1,166 @@
+// Copyright 2025 Skip
+// SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
+import SkipFuse
+import SkipUI
+
+public struct Stepper<Label> where Label : View {
+    private let value: Binding<Double>?
+    private let step: Double
+    private let minValue: Double?
+    private let maxValue: Double?
+    private let onIncrement: (() -> Void)?
+    private let onDecrement: (() -> Void)?
+    private let onEditingChanged: ((Bool) -> Void)?
+    private let label: Label
+}
+
+extension Stepper : View {
+    public typealias Body = Never
+}
+
+extension Stepper : SkipUIBridging {
+    public var Java_view: any SkipUI.View {
+        if onIncrement != nil || onDecrement != nil {
+            return SkipUI.Stepper(bridgedOnIncrement: onIncrement, bridgedOnDecrement: onDecrement, bridgedOnEditingChanged: onEditingChanged, bridgedLabel: label.Java_viewOrEmpty)
+        } else {
+            return SkipUI.Stepper(getValue: { value?.wrappedValue ?? 0.0 }, setValue: { value?.wrappedValue = $0 }, step: step, minValue: minValue, maxValue: maxValue, bridgedOnEditingChanged: onEditingChanged, bridgedLabel: label.Java_viewOrEmpty)
+        }
+    }
+}
+
+// MARK: - Custom increment/decrement initializers
+
+extension Stepper {
+    public init(@ViewBuilder label: () -> Label, onIncrement: (() -> Void)?, onDecrement: (() -> Void)?, onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
+        self.value = nil
+        self.step = 1.0
+        self.minValue = nil
+        self.maxValue = nil
+        self.onIncrement = onIncrement
+        self.onDecrement = onDecrement
+        self.onEditingChanged = onEditingChanged
+        self.label = label()
+    }
+}
+
+extension Stepper where Label == Text {
+    public init(_ titleKey: LocalizedStringKey, onIncrement: (() -> Void)?, onDecrement: (() -> Void)?, onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
+        self.init(label: { Text(titleKey) }, onIncrement: onIncrement, onDecrement: onDecrement, onEditingChanged: onEditingChanged)
+    }
+
+    @_disfavoredOverload public init(_ titleResource: AndroidLocalizedStringResource, onIncrement: (() -> Void)?, onDecrement: (() -> Void)?, onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
+        self.init(label: { Text(titleResource) }, onIncrement: onIncrement, onDecrement: onDecrement, onEditingChanged: onEditingChanged)
+    }
+
+    @_disfavoredOverload public init<S>(_ title: S, onIncrement: (() -> Void)?, onDecrement: (() -> Void)?, onEditingChanged: @escaping (Bool) -> Void = { _ in }) where S : StringProtocol {
+        self.init(label: { Text(title) }, onIncrement: onIncrement, onDecrement: onDecrement, onEditingChanged: onEditingChanged)
+    }
+}
+
+// MARK: - Value binding initializers (no bounds)
+
+extension Stepper {
+    public init(value: Binding<Int>, step: Int = 1, @ViewBuilder label: () -> Label, onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
+        self.value = Binding(get: { Double(value.wrappedValue) }, set: { value.wrappedValue = Int($0) })
+        self.step = Double(step)
+        self.minValue = nil
+        self.maxValue = nil
+        self.onIncrement = nil
+        self.onDecrement = nil
+        self.onEditingChanged = onEditingChanged
+        self.label = label()
+    }
+
+    public init(value: Binding<Double>, step: Double = 1.0, @ViewBuilder label: () -> Label, onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
+        self.value = value
+        self.step = step
+        self.minValue = nil
+        self.maxValue = nil
+        self.onIncrement = nil
+        self.onDecrement = nil
+        self.onEditingChanged = onEditingChanged
+        self.label = label()
+    }
+}
+
+extension Stepper where Label == Text {
+    // Int value initializers (no bounds)
+    public init(_ titleKey: LocalizedStringKey, value: Binding<Int>, step: Int = 1, onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
+        self.init(value: value, step: step, label: { Text(titleKey) }, onEditingChanged: onEditingChanged)
+    }
+
+    @_disfavoredOverload public init(_ titleResource: AndroidLocalizedStringResource, value: Binding<Int>, step: Int = 1, onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
+        self.init(value: value, step: step, label: { Text(titleResource) }, onEditingChanged: onEditingChanged)
+    }
+
+    @_disfavoredOverload public init<S>(_ title: S, value: Binding<Int>, step: Int = 1, onEditingChanged: @escaping (Bool) -> Void = { _ in }) where S : StringProtocol {
+        self.init(value: value, step: step, label: { Text(title) }, onEditingChanged: onEditingChanged)
+    }
+
+    // Double value initializers (no bounds)
+    public init(_ titleKey: LocalizedStringKey, value: Binding<Double>, step: Double = 1.0, onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
+        self.init(value: value, step: step, label: { Text(titleKey) }, onEditingChanged: onEditingChanged)
+    }
+
+    @_disfavoredOverload public init(_ titleResource: AndroidLocalizedStringResource, value: Binding<Double>, step: Double = 1.0, onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
+        self.init(value: value, step: step, label: { Text(titleResource) }, onEditingChanged: onEditingChanged)
+    }
+
+    @_disfavoredOverload public init<S>(_ title: S, value: Binding<Double>, step: Double = 1.0, onEditingChanged: @escaping (Bool) -> Void = { _ in }) where S : StringProtocol {
+        self.init(value: value, step: step, label: { Text(title) }, onEditingChanged: onEditingChanged)
+    }
+}
+
+// MARK: - Value binding initializers (with bounds)
+
+extension Stepper {
+    public init(value: Binding<Int>, in bounds: ClosedRange<Int>, step: Int = 1, @ViewBuilder label: () -> Label, onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
+        self.value = Binding(get: { Double(value.wrappedValue) }, set: { value.wrappedValue = Int($0) })
+        self.step = Double(step)
+        self.minValue = Double(bounds.lowerBound)
+        self.maxValue = Double(bounds.upperBound)
+        self.onIncrement = nil
+        self.onDecrement = nil
+        self.onEditingChanged = onEditingChanged
+        self.label = label()
+    }
+
+    public init(value: Binding<Double>, in bounds: ClosedRange<Double>, step: Double = 1.0, @ViewBuilder label: () -> Label, onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
+        self.value = value
+        self.step = step
+        self.minValue = bounds.lowerBound
+        self.maxValue = bounds.upperBound
+        self.onIncrement = nil
+        self.onDecrement = nil
+        self.onEditingChanged = onEditingChanged
+        self.label = label()
+    }
+}
+
+extension Stepper where Label == Text {
+    // Int value initializers (with bounds)
+    public init(_ titleKey: LocalizedStringKey, value: Binding<Int>, in bounds: ClosedRange<Int>, step: Int = 1, onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
+        self.init(value: value, in: bounds, step: step, label: { Text(titleKey) }, onEditingChanged: onEditingChanged)
+    }
+
+    @_disfavoredOverload public init(_ titleResource: AndroidLocalizedStringResource, value: Binding<Int>, in bounds: ClosedRange<Int>, step: Int = 1, onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
+        self.init(value: value, in: bounds, step: step, label: { Text(titleResource) }, onEditingChanged: onEditingChanged)
+    }
+
+    @_disfavoredOverload public init<S>(_ title: S, value: Binding<Int>, in bounds: ClosedRange<Int>, step: Int = 1, onEditingChanged: @escaping (Bool) -> Void = { _ in }) where S : StringProtocol {
+        self.init(value: value, in: bounds, step: step, label: { Text(title) }, onEditingChanged: onEditingChanged)
+    }
+
+    // Double value initializers (with bounds)
+    public init(_ titleKey: LocalizedStringKey, value: Binding<Double>, in bounds: ClosedRange<Double>, step: Double = 1.0, onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
+        self.init(value: value, in: bounds, step: step, label: { Text(titleKey) }, onEditingChanged: onEditingChanged)
+    }
+
+    @_disfavoredOverload public init(_ titleResource: AndroidLocalizedStringResource, value: Binding<Double>, in bounds: ClosedRange<Double>, step: Double = 1.0, onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
+        self.init(value: value, in: bounds, step: step, label: { Text(titleResource) }, onEditingChanged: onEditingChanged)
+    }
+
+    @_disfavoredOverload public init<S>(_ title: S, value: Binding<Double>, in bounds: ClosedRange<Double>, step: Double = 1.0, onEditingChanged: @escaping (Bool) -> Void = { _ in }) where S : StringProtocol {
+        self.init(value: value, in: bounds, step: step, label: { Text(title) }, onEditingChanged: onEditingChanged)
+    }
+}


### PR DESCRIPTION
Complement to https://github.com/skiptools/skip-ui/pull/304

- added Stepper bridging with onIncrement, onDecrement, and onEditingChanged callbacks
- added DatePicker ClosedRange<Date> initializers with min/max date bridging
- added Slider onEditingChanged callback bridging

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device
