### PR TITLE
add scrollview modifiers scrollDisabled, scrollIndicators(.hidden)

### DIFF
--- a/Sources/SkipSwiftUI/Containers/ScrollView.swift
+++ b/Sources/SkipSwiftUI/Containers/ScrollView.swift
@@ -131,20 +131,26 @@ extension ScrollGeometry : CustomDebugStringConvertible {
 }
 
 public struct ScrollIndicatorVisibility : Equatable {
+    public let rawValue: Int
+
+    private init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
     public static var automatic: ScrollIndicatorVisibility {
-        return ScrollIndicatorVisibility()
+        return ScrollIndicatorVisibility(rawValue: 0) // For bridging
     }
 
     public static var visible: ScrollIndicatorVisibility {
-        return ScrollIndicatorVisibility()
+        return ScrollIndicatorVisibility(rawValue: 1) // For bridging
     }
 
     public static var hidden: ScrollIndicatorVisibility {
-        return ScrollIndicatorVisibility()
+        return ScrollIndicatorVisibility(rawValue: 2) // For bridging
     }
 
     public static var never: ScrollIndicatorVisibility {
-        return ScrollIndicatorVisibility()
+        return ScrollIndicatorVisibility(rawValue: 3) // For bridging
     }
 }
 
@@ -585,14 +591,16 @@ extension View {
         }
     }
 
-    @available(*, unavailable)
     nonisolated public func scrollDisabled(_ disabled: Bool) -> some View {
-        stubView()
+        return ModifierView(target: self) {
+            $0.Java_viewOrEmpty.scrollDisabled(disabled)
+        }
     }
 
-    @available(*, unavailable)
     nonisolated public func scrollIndicators(_ visibility: ScrollIndicatorVisibility, axes: Axis.Set = [.vertical, .horizontal]) -> some View {
-        stubView()
+        return ModifierView(target: self) {
+            $0.Java_viewOrEmpty.scrollIndicators(bridgedVisibility: visibility.rawValue, bridgedAxes: Int(axes.rawValue))
+        }
     }
 
     @available(*, unavailable)


### PR DESCRIPTION
Complement to https://github.com/skiptools/skip-ui/pull/305

scroll indicators are hidden by default on android, so this is just for API completeness

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device