### PR TITLE
Fix `.navigationBarHidden(_ hidden: Bool)` modifier

### DIFF
--- a/Sources/SkipSwiftUI/Containers/Navigation.swift
+++ b/Sources/SkipSwiftUI/Containers/Navigation.swift
@@ -528,7 +528,7 @@ extension View {
     }
 
     nonisolated public func navigationBarHidden(_ hidden: Bool) -> some View {
-        return toolbarVisibility(.hidden, for: .navigationBar)
+        return toolbarVisibility(hidden ? .hidden : .visible, for: .navigationBar)
     }
 }
 


### PR DESCRIPTION
The conditional `navigationBarHidden(_ hidden: Bool)` modifier wasn't honoring the `hidden` parameter. This fixes that to ensure it dynamically hides or shows the navigation bar when specified.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

