### PR TITLE
UIImage Additions

### DIFF
--- a/Sources/SkipSwiftUI/UIKit/UIImage.swift
+++ b/Sources/SkipSwiftUI/UIKit/UIImage.swift
@@ -109,10 +109,13 @@ open class UIImage : NSObject /*, NSSecureCoding */, @unchecked Sendable {
     public init(ciImage: Any /* CIImage */, scale: CGFloat, orientation: UIImage.Orientation) {
         fatalError()
     }
+    
+    private init(skipImage: SkipUI.UIImage) {
+        self.uiImage = skipImage
+    }
 
-    @available(*, unavailable)
     open var size: CGSize {
-        fatalError()
+        return .init(width: uiImage.bridgedWidth, height: uiImage.bridgedHeight)
     }
 
     @available(*, unavailable)
@@ -319,9 +322,11 @@ open class UIImage : NSObject /*, NSSecureCoding */, @unchecked Sendable {
         fatalError()
     }
 
-    @available(*, unavailable)
     open func preparingThumbnail(of size: CGSize) -> UIImage? {
-        fatalError()
+        if let uiImage = uiImage.preparingThumbnail(width: size.width, height: size.height) {
+            return UIImage(skipImage: uiImage)
+        }
+        return nil
     }
 
     @available(*, unavailable)
@@ -329,9 +334,11 @@ open class UIImage : NSObject /*, NSSecureCoding */, @unchecked Sendable {
         fatalError()
     }
 
-    @available(*, unavailable)
     open func byPreparingThumbnail(ofSize size: CGSize) async -> UIImage? {
-        fatalError()
+        if let uiImage = await uiImage.byPreparingThumbnail(width: size.width, height: size.height) {
+            return UIImage(skipImage: uiImage)
+        }
+        return nil
     }
 
     @available(*, unavailable)


### PR DESCRIPTION
This is the corresponding update to https://github.com/skiptools/skip-ui/pull/392

It adds the following UIImage api surfaces:
1. Image `.size`
2. Thumbnail creation with `.byPreparingThumbnail(ofSize: _)`

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

