### PR TITLE
Add support for `.buttonStyle(.m3Text)` for Material 3 TextButton

### DIFF
--- a/Sources/SkipSwiftUI/Controls/Button.swift
+++ b/Sources/SkipSwiftUI/Controls/Button.swift
@@ -231,6 +231,17 @@ public struct GlassButtonStyle : PrimitiveButtonStyle {
     public let identifier = 5 // For bridging
 }
 
+public struct M3TextButtonStyle : PrimitiveButtonStyle {
+    public init() {
+    }
+
+    @MainActor @preconcurrency public func makeBody(configuration: M3TextButtonStyle.Configuration) -> some View {
+        stubView()
+    }
+
+    public let identifier = 7 // For bridging
+}
+
 @MainActor @preconcurrency public protocol PrimitiveButtonStyle {
     associatedtype Body : View
 
@@ -281,6 +292,12 @@ extension PrimitiveButtonStyle where Self == GlassButtonStyle {
     @available(*, unavailable)
     @MainActor @preconcurrency public static var glass: GlassButtonStyle {
         fatalError()
+    }
+}
+
+extension PrimitiveButtonStyle where Self == M3TextButtonStyle {
+    @MainActor @preconcurrency public static var m3Text: M3TextButtonStyle {
+        return M3TextButtonStyle()
     }
 }
 


### PR DESCRIPTION
* Depends on https://github.com/skiptools/skip-ui/pull/406

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor did this. I tested it in the Fuse Showcase.