### PR TITLE
Add `.subcomposeAsyncImage()` and AsyncImagePhase.empty(Image?)

### DIFF
--- a/Sources/SkipSwiftUI/Components/AsyncImage.swift
+++ b/Sources/SkipSwiftUI/Components/AsyncImage.swift
@@ -16,7 +16,16 @@ public struct AsyncImage<Content> where Content : View {
     public init<I, P>(url: URL?, scale: CGFloat = 1, @ViewBuilder content: @escaping (Image) -> I, @ViewBuilder placeholder: @escaping () -> P) where Content == AnyView /* _ConditionalContent<I, P> */, I : View, P : View {
         self.init(url: url, scale: scale, transaction: Transaction()) { phase in
             switch phase {
-            case .empty, .failure:
+            case .empty:
+                if let image = phase.image {
+                    ZStack {
+                        Color.clear // Showing a placeholder here prevents layout shift if the image is 0x0 on the first frame
+                        image
+                    }
+                } else {
+                    placeholder()
+                }
+            case .failure:
                 placeholder()
             case .success(let image):
                 content(image)
@@ -54,18 +63,22 @@ extension AsyncImage : View {
 
 extension AsyncImage : SkipUIBridging {
     public var Java_view: any SkipUI.View {
-        let factory: ((SkipUI.Image?, (any Error)?) -> any SkipUI.View)?
+        let factory: ((SkipUI.AsyncImageBridgedContentArguments) -> any SkipUI.View)?
         if let content {
-            factory = { image, error in
+            factory = { args in
                 let phase: AsyncImagePhase
-                if image == nil && error == nil {
-                    phase = .empty
-                } else if let error {
+                if let error = args.error {
                     phase = .failure(error)
+                } else if let image = args.image {
+                    let imageSpec = ImageSpec(.java(image))
+                    let image = Image(spec: imageSpec)
+                    if args.isEmpty {
+                        phase = .empty(image)
+                    } else {
+                        phase = .success(image)
+                    }
                 } else {
-
-                    var imageSpec = ImageSpec(.java(image!))
-                    phase = .success(Image(spec: imageSpec))
+                    phase = .empty(nil)
                 }
                 let result = content(phase)
 
@@ -79,13 +92,15 @@ extension AsyncImage : SkipUIBridging {
 }
 
 public enum AsyncImagePhase : Sendable {
-    case empty
+    case empty(Image?)
     case success(Image)
     case failure(any Error)
 
     public var image: Image? {
         switch self {
         case .success(let image):
+            return image
+        case .empty(let image):
             return image
         default:
             return nil

--- a/Sources/SkipSwiftUI/View/AdditionalViewModifiers.swift
+++ b/Sources/SkipSwiftUI/View/AdditionalViewModifiers.swift
@@ -231,6 +231,17 @@ extension View {
     }
 }
 
+#if os(Android)
+extension View {
+    /// When `true`, SkipUI ``Image`` / ``AsyncImage`` use Coil ``SubcomposeAsyncImage`` (slower; avoids first-frame empty state with cached images). Default is `false`.
+    nonisolated public func subcomposeAsyncImage(_ enabled: Bool = true) -> some View {
+        return ModifierView(target: self) {
+            $0.Java_viewOrEmpty.subcomposeAsyncImage(enabled)
+        }
+    }
+}
+#endif
+
 extension View {
     @inlinable nonisolated public func edgesIgnoringSafeArea(_ edges: Edge.Set) -> some View {
         return ignoresSafeArea(edges: edges)


### PR DESCRIPTION
* Depends on https://github.com/skiptools/skip-ui/pull/423

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor did a first draft, and I refactored it. I tested it with Showcase Fuse.