### PR TITLE
Re-export SkipSwiftUI from SkipFuseUI under SKIP_BRIDGE on non-Android

### DIFF
--- a/Sources/SkipFuseUI/SwiftUI.swift
+++ b/Sources/SkipFuseUI/SwiftUI.swift
@@ -3,6 +3,8 @@
 
 #if os(Android)
 @_exported import SkipSwiftUI
+#elseif SKIP_BRIDGE
+@_exported import SkipSwiftUI
 #elseif canImport(SwiftUI)
 @_exported import SwiftUI
 #endif


### PR DESCRIPTION
## Problem

Auto-generated bridge files in downstream packages (notably `skip-firebase`'s `SkipFirebaseAnalyticsSwiftUI_Bridge.swift` and `skip-kit`'s `DocumentPicker_Bridge.swift`, `MediaPicker_Bridge.swift`, `WebBrowser_Bridge.swift`, etc.) emit qualified references against the Android API surface while only importing `SkipFuseUI`:

```swift
import SkipFuseUI

extension SkipSwiftUI.View {
    public func analyticsScreen(...) -> (some SkipSwiftUI.View) {
        return SkipSwiftUI.ModifierView(target: self) { ... }
    }
}
```

On Android this compiles because `SkipFuseUI`'s `SwiftUI.swift` already does `@_exported import SkipSwiftUI`. On macOS, the existing code only re-exports Apple's `SwiftUI`, so `SkipSwiftUI` is not in scope and the bridge fails to build with:

```
error: cannot find type 'SkipSwiftUI' in scope
```

This blocks any project that pulls in `skip-firebase` (>= 0.17.x) or any other package whose bridge generator emits `SkipSwiftUI.*` qualified types alongside `import SkipFuseUI`.

## Why not always re-export `SkipSwiftUI` on macOS

A naive `@_exported import SkipSwiftUI` alongside `@_exported import SwiftUI` makes normal macOS clients fail with `'Binding' is ambiguous for type lookup in this context` (and the same for `View`, `Text`, etc.) because `SkipSwiftUI` defines its own parallel types that collide with Apple's `SwiftUI`.

## Fix

Gate the `SkipSwiftUI` re-export behind `#if SKIP_BRIDGE`. The `skipstone` plugin sets `SKIP_BRIDGE` only when compiling generated bridge sources, so:

- **Android** — unchanged, re-exports `SkipSwiftUI`.
- **iOS / macOS normal compilation** — unchanged, re-exports `SwiftUI`.
- **macOS bridge compilation (`SKIP_BRIDGE=1`)** — now re-exports `SkipSwiftUI`, resolving `SkipSwiftUI.View` / `SkipSwiftUI.ModifierView` qualifiers without leaking parallel types into normal client code.

## Diff

```diff
 #if os(Android)
 @_exported import SkipSwiftUI
+#elseif SKIP_BRIDGE
+@_exported import SkipSwiftUI
 #elseif canImport(SwiftUI)
 @_exported import SwiftUI
 #endif
```

## Verification

Reproduced against a project consuming `skip-firebase` 0.18.0 + `skip-ui` 1.54.0 + `skip` 1.8.14. Before the change `swift test` fails at `SkipFirebaseAnalyticsSwiftUI_Bridge.swift:5` with `cannot find type 'SkipSwiftUI' in scope`. With this branch pinned via package override, that error and all the downstream `'Binding' is ambiguous` errors in `skip-kit` bridges are gone, and the build proceeds past the previously failing bridge sources.