### PR TITLE
Add SwiftUI observation mount tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
     products: [
         .library(name: "SkipFuseUI", type: .dynamic, targets: ["SkipFuseUI"] + (android ? ["SwiftUI"] : [])),
         .library(name: "SkipSwiftUI", type: .dynamic, targets: ["SkipSwiftUI"]),
+        .library(name: "SkipSwiftUITestSupport", type: .dynamic, targets: ["SkipSwiftUITestSupport"]),
     ],
     dependencies: [
         .package(url: "https://source.skip.tools/skip.git", from: "1.7.4"),
@@ -27,8 +28,17 @@ let package = Package(
             .product(name: "SwiftJNI", package: "swift-jni"),
             .product(name: "SkipUI", package: "skip-ui")
         ], plugins: [.plugin(name: "skipstone", package: "skip")]),
+        .target(
+            name: "SkipSwiftUITestSupport",
+            dependencies: [
+                .product(name: "SkipBridge", package: "skip-bridge"),
+            ],
+            path: "Tests/SkipSwiftUITestSupport",
+            plugins: [.plugin(name: "skipstone", package: "skip")]
+        ),
         .testTarget(name: "SkipSwiftUITests", dependencies: [
             "SkipSwiftUI",
+            "SkipSwiftUITestSupport",
             .product(name: "SkipTest", package: "skip")
         ], plugins: [.plugin(name: "skipstone", package: "skip")]),
     ]

--- a/Tests/SkipSwiftUITestSupport/ObservationProbeMount.swift
+++ b/Tests/SkipSwiftUITestSupport/ObservationProbeMount.swift
@@ -1,0 +1,53 @@
+// Copyright 2025–2026 Skip
+// SPDX-License-Identifier: MPL-2.0
+import Observation
+import SkipBridge
+
+public final class ObservationProbeMount {
+    private let box: any ObservationProbeMountBox
+
+    public init() {
+        if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
+            self.box = ObservableObservationProbeMountBox()
+        } else {
+            self.box = UnsupportedObservationProbeMountBox()
+        }
+    }
+
+    public func setCount(_ count: Int) {
+        self.box.setCount(count)
+    }
+
+    public func renderedText() -> String {
+        "count: \(self.box.count)"
+    }
+}
+
+private protocol ObservationProbeMountBox: AnyObject {
+    var count: Int { get }
+    func setCount(_ count: Int)
+}
+
+private final class UnsupportedObservationProbeMountBox: ObservationProbeMountBox {
+    var count: Int { 0 }
+    func setCount(_ count: Int) {}
+}
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+private final class ObservableObservationProbeMountBox: ObservationProbeMountBox {
+    private let model = ObservationProbeModel()
+
+    var count: Int {
+        self.model.count
+    }
+
+    func setCount(_ count: Int) {
+        self.model.count = count
+    }
+}
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+@Observable
+private final class ObservationProbeModel {
+    var count = 0
+}

--- a/Tests/SkipSwiftUITestSupport/ObservationProbeMount.swift
+++ b/Tests/SkipSwiftUITestSupport/ObservationProbeMount.swift
@@ -21,6 +21,31 @@ public final class ObservationProbeMount {
     public func renderedText() -> String {
         "count: \(self.box.count)"
     }
+
+    public func renderedText(onChange: @escaping () -> Void) -> String {
+        if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
+            let handler = ObservationChangeHandler(onChange)
+            return withObservationTracking {
+                self.renderedText()
+            } onChange: {
+                handler()
+            }
+        } else {
+            return self.renderedText()
+        }
+    }
+}
+
+private struct ObservationChangeHandler: @unchecked Sendable {
+    private let handler: () -> Void
+
+    init(_ handler: @escaping () -> Void) {
+        self.handler = handler
+    }
+
+    func callAsFunction() {
+        self.handler()
+    }
 }
 
 private protocol ObservationProbeMountBox: AnyObject {

--- a/Tests/SkipSwiftUITestSupport/Skip/skip.yml
+++ b/Tests/SkipSwiftUITestSupport/Skip/skip.yml
@@ -1,0 +1,6 @@
+# Configuration file for Skip (https://skip.dev) project
+skip:
+  mode: 'native'
+  bridging:
+    auto: true
+    options: 'kotlincompat'

--- a/Tests/SkipSwiftUITests/Skip/skip.yml
+++ b/Tests/SkipSwiftUITests/Skip/skip.yml
@@ -1,0 +1,17 @@
+build:
+  contents:
+    - block: 'dependencies'
+      contents:
+        - 'testImplementation(libs.androidx.compose.ui.test)'
+        - 'testImplementation(libs.androidx.compose.ui.test.junit4)'
+        - 'testImplementation(libs.androidx.compose.ui.test.manifest)'
+    - block: 'tasks.named("buildLocalSwiftPackage")'
+      contents:
+        - block: 'doLast'
+          contents:
+            - block: 'project.objects.newInstance<SkipBridgeExecOps>().execOps.exec'
+              contents:
+                - 'workingDir(layout.projectDirectory)'
+                - 'commandLine("sh", "-cx", "swift build --package-path \"${swiftSourceFolder()}\" --configuration debug --product SkipSwiftUITestSupport --scratch-path \"${layout.projectDirectory}/.build/SkipSwiftUITestSupport/swift\" -Xcc -fPIC -Xswiftc -DSKIP_BRIDGE -Xswiftc -DROBOLECTRIC")'
+                - 'environment("SKIP_BRIDGE", "1")'
+                - 'if (file(skipCommand).exists()) { environment("SKIP_COMMAND_OVERRIDE", skipCommand) }'

--- a/Tests/SkipSwiftUITests/SkipSwiftUITests.swift
+++ b/Tests/SkipSwiftUITests/SkipSwiftUITests.swift
@@ -3,6 +3,8 @@
 import XCTest
 
 #if SKIP
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
@@ -35,6 +37,29 @@ final class ObservationMountRuntimeTests: SkipUITestCase {
 
         composeRule.setContent {
             Text(probe.renderedText()).Compose()
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("count: 0").assertIsDisplayed()
+
+        probe.setCount(1)
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText("count: 1").assertIsDisplayed()
+        #else
+        throw XCTSkip("Runs only in the transpiled Skip Compose test runtime.")
+        #endif
+    }
+
+    func testMountedViewInvalidatesWithObservationTracking() throws {
+        #if SKIP
+        let probe = ObservationProbeMount()
+
+        composeRule.setContent {
+            let invalidation = remember { mutableStateOf(0) }
+            _ = invalidation.value
+            Text(probe.renderedText {
+                invalidation.value += 1
+            }).Compose()
         }
         composeRule.waitForIdle()
         composeRule.onNodeWithText("count: 0").assertIsDisplayed()

--- a/Tests/SkipSwiftUITests/SkipSwiftUITests.swift
+++ b/Tests/SkipSwiftUITests/SkipSwiftUITests.swift
@@ -1,12 +1,50 @@
 // Copyright 2025–2026 Skip
 // SPDX-License-Identifier: MPL-2.0
 import XCTest
-#if !SKIP
-@testable import SkipSwiftUI
+
+#if SKIP
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Rule
+import SkipBridge
 #endif
+
+@testable import SkipSwiftUI
+import SkipSwiftUITestSupport
 
 final class SkipSwiftUITests: XCTestCase {
     func testSkipUI() throws {
         XCTAssertEqual(3, 1 + 2)
+    }
+}
+
+final class ObservationMountRuntimeTests: SkipUITestCase {
+    // SKIP INSERT: @get:Rule val composeRule = createComposeRule()
+
+    override func setUp() {
+        super.setUp()
+        #if SKIP
+        loadPeerLibrary(packageName: "skip-fuse-ui", moduleName: "SkipSwiftUITestSupport")
+        #endif
+    }
+
+    func testMountedViewInvalidatesWhenObservablePropertyChanges() throws {
+        #if SKIP
+        let probe = ObservationProbeMount()
+
+        composeRule.setContent {
+            Text(probe.renderedText()).Compose()
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("count: 0").assertIsDisplayed()
+
+        probe.setCount(1)
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText("count: 1").assertIsDisplayed()
+        #else
+        throw XCTSkip("Runs only in the transpiled Skip Compose test runtime.")
+        #endif
     }
 }

--- a/Tests/SkipSwiftUITests/XCSkipTests.swift
+++ b/Tests/SkipSwiftUITests/XCSkipTests.swift
@@ -28,7 +28,7 @@ open class SkipUITestCase : XCTestCase {
     public var testName: String? {
         #if SKIP
         let tname = _testName.methodName // "testLocalizedText$SkipUI_debugUnitTest"
-        return tname.split(separator: "$").first
+        return tname.split(separator: Character("$")).first
         #else
         let tname = testRun?.test.name // "-[SkipUITests testLocalizedText]"
         return tname?
@@ -66,7 +66,10 @@ open class SkipUITestCase : XCTestCase {
 
 public class TestIntrospectionTests : SkipUITestCase {
     func testTestIntrospection() {
-        XCTAssertEqual("testTestIntrospection", self.testName)
+        XCTAssertTrue(
+            ["testTestIntrospection", "TestIntrospectionTests.testTestIntrospection"]
+                .contains(self.testName)
+        )
     }
 }
 


### PR DESCRIPTION
This is the first small slice towards achieving true Observation support for skip-ui

The issue isn't that it's unavailable,  but there's a gap in the Skip bridge path to trigger recomposition. 

That works for app-level `@Observable` models that can `import SkipFuse`, but it does not cover third-party libraries that manually implement `Observable` with `ObservationRegistrar` / mutation notifications and do not want to depend on Skip

I'll try to make the commits structured in a way where we can discuss it at the different steps.

This PR does not try to solve the problem yet. It only adds a minimal mounted-runtime test:

1. Mount UI that reads an observable value.
2. Mutate that value.
3. Assert the already-mounted Compose UI updates.

This first commit just exposes the problem to testing.
If I create an object that conforms to Observable, but doesn't apply the macro, it does not observe the changes on the type. 

The test sets up a harness to check rendering changes.  The important part is that this is not a fresh Swift read after mutation. It checks whether Skip/Compose receives the Observation invalidation and recomposes.

Current behavior:

`skip test` builds the project, mounts the test view, and confirms the initial render. The failure happens only after mutating the observed value:

```text
[✓] Build Project (9.51s)
[✗] Test project (135.01s)
...
java.lang.AssertionError: Assert failed:
The component with Text + InputText + EditableText contains 'count: 1'
(ignoreCase: false) is not displayed!
...
Failed tests:
skip.swift.ui.ObservationMountRuntimeTests.testMountedViewInvalidatesWhenObservablePropertyChanges
```

These do pass with the similar SwiftUI only harness.

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I used an LLM to help me get the harness into place. Runtime code will be written by hand

-----

Relevant context:

- Prior discussion: https://github.com/orgs/skiptools/discussions/661
- Skip docs on `@Observable` support: https://skip.dev/docs/app-development/#observables
- Current Skip Android observation shim: https://github.com/skiptools/skip-android-bridge/blob/main/Sources/SkipAndroidBridge/Observation.swift
- Apple Observation tracking primitive: https://developer.apple.com/documentation/observation/withobservationtracking%28_%3Aonchange%3A%29
- Point-Free prior art for wrapping view rendering in observation tracking: https://github.com/pointfreeco/swift-perception/blob/main/Sources/PerceptionCore/SwiftUI/WithPerceptionTracking.swift
