### PR TITLE
Material: render over the adaptive surface color, not fixed white

### DIFF
--- a/Sources/SkipSwiftUI/Graphics/Material.swift
+++ b/Sources/SkipSwiftUI/Graphics/Material.swift
@@ -51,8 +51,9 @@ public struct Material : ShapeStyle, RawRepresentable, Hashable, Sendable {
     /// A material matching the style of system toolbars.
     public static let bar = Material(rawValue: 5)
 
-    /// Returns the opacity for this material (light mode values).
-    /// Note: This is a simplified replica - no blur effect, just semi-transparent white overlay.
+    /// Returns the scrim opacity for this material level. Thicker materials are
+    /// more opaque. Simplified replica — no Gaussian blur, just a translucent
+    /// scrim over the adaptive surface color (see `Java_view`).
     private var materialOpacity: Double {
         switch rawValue {
         case Self.ultraThin.rawValue:
@@ -71,7 +72,11 @@ public struct Material : ShapeStyle, RawRepresentable, Hashable, Sendable {
     }
 
     public var Java_view: any SkipUI.View {
-        return SkipUI.Color._white.opacity(materialOpacity)
+        // Use the adaptive surface color (MaterialTheme surface) rather than a
+        // fixed white so materials read correctly in dark mode — a translucent
+        // dark scrim, matching iOS's dark-appearance materials — and in light
+        // mode. A fixed white overlay looked washed-out / too light on dark UIs.
+        return SkipUI.Color._background.opacity(materialOpacity)
     }
 }
 


### PR DESCRIPTION
`Material.Java_view` backed every `.ultraThinMaterial`/`.regularMaterial`/etc. with a fixed white scrim (`Color._white.opacity(...)`). On dark UIs that reads washed-out and too light — the opposite of iOS, whose materials are dark in dark appearance. Switch the base to the adaptive `Color._background` (MaterialTheme surface): a translucent dark scrim in dark mode, light in light mode. Scheme-aware, no SkipUI change. Verified on device across all levels (ultraThin→ultraThick) over a gradient — the backdrop shows through, darkening as the material thickens.