### PR TITLE
Bridge fixedSize() / fixedSize(horizontal:vertical:)

### DIFF
--- a/Sources/SkipSwiftUI/View/AdditionalViewModifiers.swift
+++ b/Sources/SkipSwiftUI/View/AdditionalViewModifiers.swift
@@ -145,6 +145,16 @@ extension View {
             $0.Java_viewOrEmpty.saturation(amount)
         }
     }
+
+    nonisolated public func fixedSize(horizontal: Bool, vertical: Bool) -> some View {
+        return ModifierView(target: self) {
+            $0.Java_viewOrEmpty.fixedSize(horizontal: horizontal, vertical: vertical)
+        }
+    }
+
+    nonisolated public func fixedSize() -> some View {
+        return fixedSize(horizontal: true, vertical: true)
+    }
 }
 
 extension View {


### PR DESCRIPTION
## What

Bridges `fixedSize()` and `fixedSize(horizontal:vertical:)`, previously unavailable in SkipSwiftUI.

## How

Forwards to SkipUI's new `fixedSize` bridge (which maps the fixed axis to `Modifier.wrapContentWidth/Height(unbounded: true)`).

## Pairing

Requires skiptools/skip-ui#454 (the SkipUI implementation). This PR will not function against a SkipUI without it.

## Testing

Verified on an Android emulator with a SkipFuse app: vertical fixedSize shows a height-clipped text in full; horizontal fixedSize keeps a label on one line at its ideal width; `fixedSize()` prevents truncation when squeezed in an `HStack`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
