### PR TITLE
Implement presentationDragIndicator(_:)

### DIFF
--- a/Sources/SkipSwiftUI/Layout/Presentation.swift
+++ b/Sources/SkipSwiftUI/Layout/Presentation.swift
@@ -432,9 +432,10 @@ extension View {
         stubView()
     }
 
-    @available(*, unavailable)
     nonisolated public func presentationDragIndicator(_ visibility: Visibility) -> some View {
-        stubView()
+        return ModifierView(target: self) {
+            $0.Java_viewOrEmpty.presentationDragIndicator(bridgedVisibility: visibility.rawValue)
+        }
     }
 }
 


### PR DESCRIPTION
## What

Implements `presentationDragIndicator(_:)` in the SkipSwiftUI layer (currently `@available(*, unavailable)`).

## How

Forwards to skip-ui's bridged variant using the `Visibility` raw value, mirroring the existing `confirmationDialog(..., bridgedTitleVisibility:)` forwarding in this same file.

```swift
nonisolated public func presentationDragIndicator(_ visibility: Visibility) -> some View {
    return ModifierView(target: self) {
        $0.Java_viewOrEmpty.presentationDragIndicator(bridgedVisibility: visibility.rawValue)
    }
}
```

## Verification

Built and exercised on an Android emulator from a SkipFuse app: `.visible` / `.automatic` show the sheet grab handle, `.hidden` suppresses it with no content shift.

## Paired PR

Requires the SkipUI implementation + bridge: skiptools/skip-ui#455
