### PR TITLE
Simultaneous gesture partial support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         .package(url: "https://source.skip.tools/skip-bridge.git", "0.16.7"..<"2.0.0"),
         .package(url: "https://source.skip.tools/skip-android-bridge.git", "0.6.1"..<"2.0.0"),
         .package(url: "https://source.skip.tools/swift-jni.git", "0.3.1"..<"2.0.0"),
-        .package(url: "https://github.com/tifroz/skip-ui.git", branch: "simultaneousGesture_support"),
+        .package(url: "https://source.skip.tools/skip-ui.git", branch: "main"),
     ],
     targets: [
         .target(name: "SkipFuseUI", dependencies: ["SkipSwiftUI"]),

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         .package(url: "https://source.skip.tools/skip-bridge.git", "0.16.7"..<"2.0.0"),
         .package(url: "https://source.skip.tools/skip-android-bridge.git", "0.6.1"..<"2.0.0"),
         .package(url: "https://source.skip.tools/swift-jni.git", "0.3.1"..<"2.0.0"),
-        .package(url: "https://source.skip.tools/skip-ui.git", from: "1.50.0"),
+        .package(url: "https://github.com/tifroz/skip-ui.git", branch: "simultaneousGesture_support"),
     ],
     targets: [
         .target(name: "SkipFuseUI", dependencies: ["SkipSwiftUI"]),

--- a/README.md
+++ b/README.md
@@ -120,11 +120,13 @@ SkipFuseUI mirrors the SwiftUI API surface for iOS 16+, including:
 - **State**: `@State`, `@Binding`, `@Environment`, `@AppStorage`, `@FocusState`
 - **Modifiers**: `.padding`, `.frame`, `.background`, `.overlay`, `.opacity`, `.rotation`, `.shadow`, `.clipShape`, `.sheet`, `.alert`, `.onAppear`, `.task`, and many more
 - **Navigation**: `NavigationStack`, `NavigationLink`, `NavigationPath`, `.navigationTitle`, `.toolbar`
-- **Gestures**: `TapGesture`, `LongPressGesture`, `DragGesture`
+- **Gestures**: `TapGesture`, `LongPressGesture`, `DragGesture`, plus partial `.simultaneousGesture` bridging for supported gesture observers
 - **Animation**: `withAnimation`, `.animation`, `.transition`, `Spring`
 - **UIKit compatibility**: `UIApplication`, `UIColor`, `UIImage`, `UIPasteboard`
 
 For the full list of supported SwiftUI components, see the [SkipUI documentation](https://skip.dev/docs/modules/skip-ui/#supported-swiftui).
+
+`simultaneousGesture` support follows SkipUI's current Android limitations: it can observe supported gestures on the same rendered view, including drag observation while scroll views continue scrolling, but only `.all` and `.none` have meaningful mask behavior. `.gesture` and `.subviews` masks are not distinguished.
 
 ## Related Documentation
 

--- a/Sources/SkipSwiftUI/System/Gesture.swift
+++ b/Sources/SkipSwiftUI/System/Gesture.swift
@@ -480,8 +480,7 @@ extension TapGesture : Gesture {
         self.rawValue = rawValue
     }
 
-    @available(*, unavailable)
-    public static let none = GestureMask(rawValue: 1) // For bridging
+    public static let none = GestureMask(rawValue: 0) // For bridging
 
     @available(*, unavailable)
     public static let gesture = GestureMask(rawValue: 2) // For bridging
@@ -543,6 +542,15 @@ extension View {
         stubView()
     }
 
+    /// Adds a gesture that may recognize at the same time as the view's other
+    /// SkipUI-supported gestures.
+    ///
+    /// Android support is partial. This currently attaches the supplied
+    /// gesture as an additional observer on the same rendered view, which is
+    /// enough for simple callback observation such as `DragGesture`. Only
+    /// `.all` and `.none` have meaningful mask behavior; `.gesture` and
+    /// `.subviews` are not distinguished. This does not implement
+    /// `highPriorityGesture` or full SwiftUI/UIKit gesture arbitration.
     nonisolated public func simultaneousGesture<T>(_ gesture: T, including mask: GestureMask = .all) -> some View where T : Gesture {
         return self.simultaneousGesture(gesture, isEnabled: !mask.isEmpty)
     }
@@ -558,6 +566,12 @@ extension View {
         stubView()
     }
 
+    /// Adds a gesture that may recognize at the same time as the view's other
+    /// SkipUI-supported gestures when `isEnabled` is true.
+    ///
+    /// Android support is partial. This is intended as a first step toward
+    /// fuller `simultaneousGesture` parity, not a complete SwiftUI gesture
+    /// arbitration implementation.
     nonisolated public func simultaneousGesture<T>(_ gesture: T, isEnabled: Bool) -> some View where T : Gesture {
         return ModifierView(target: self) {
             $0.Java_viewOrEmpty.bridgedSimultaneousGesture(gesture.Java_gesture, isEnabled: isEnabled)
@@ -575,6 +589,11 @@ extension View {
         stubView()
     }
 
+    /// Adds a named gesture that may recognize at the same time as the view's
+    /// other SkipUI-supported gestures.
+    ///
+    /// Android support is partial; the `name` is currently accepted for API
+    /// compatibility and does not alter gesture arbitration.
     nonisolated public func simultaneousGesture<T>(_ gesture: T, name: String, isEnabled: Bool = true) -> some View where T : Gesture {
         return self.simultaneousGesture(gesture, isEnabled: isEnabled)
     }

--- a/Sources/SkipSwiftUI/System/Gesture.swift
+++ b/Sources/SkipSwiftUI/System/Gesture.swift
@@ -543,9 +543,8 @@ extension View {
         stubView()
     }
 
-    @available(*, unavailable)
     nonisolated public func simultaneousGesture<T>(_ gesture: T, including mask: GestureMask = .all) -> some View where T : Gesture {
-        stubView()
+        return self.simultaneousGesture(gesture, isEnabled: !mask.isEmpty)
     }
 
     nonisolated public func gesture<T>(_ gesture: T, isEnabled: Bool) -> some View where T : Gesture {
@@ -559,9 +558,10 @@ extension View {
         stubView()
     }
 
-    @available(*, unavailable)
     nonisolated public func simultaneousGesture<T>(_ gesture: T, isEnabled: Bool) -> some View where T : Gesture {
-        stubView()
+        return ModifierView(target: self) {
+            $0.Java_viewOrEmpty.bridgedSimultaneousGesture(gesture.Java_gesture, isEnabled: isEnabled)
+        }
     }
 }
 
@@ -575,8 +575,7 @@ extension View {
         stubView()
     }
 
-    @available(*, unavailable)
     nonisolated public func simultaneousGesture<T>(_ gesture: T, name: String, isEnabled: Bool = true) -> some View where T : Gesture {
-        stubView()
+        return self.simultaneousGesture(gesture, isEnabled: isEnabled)
     }
 }

--- a/Sources/SkipSwiftUI/View/AdditionalViewModifiers.swift
+++ b/Sources/SkipSwiftUI/View/AdditionalViewModifiers.swift
@@ -406,6 +406,22 @@ extension View {
 }
 
 extension View {
+    nonisolated public func androidVerticalOverscrollPullDown(
+        isEnabled: Bool,
+        onPull: @escaping (CGFloat) -> Void,
+        onEnd: @escaping () -> Void
+    ) -> some View {
+        return ModifierView(target: self) {
+            $0.Java_viewOrEmpty.androidVerticalOverscrollPullDown(
+                isEnabled: isEnabled,
+                onPull: onPull,
+                onEnd: onEnd
+            )
+        }
+    }
+}
+
+extension View {
     /* @inlinable */ nonisolated public func opacity(_ opacity: Double) -> some View {
         return ModifierView(animatableTarget: self) {
             return $0.opacity(opacity)

--- a/Tests/SkipSwiftUITests/SkipSwiftUITests.swift
+++ b/Tests/SkipSwiftUITests/SkipSwiftUITests.swift
@@ -9,4 +9,38 @@ final class SkipSwiftUITests: XCTestCase {
     func testSkipUI() throws {
         XCTAssertEqual(3, 1 + 2)
     }
+
+    #if !SKIP
+    func testTypedEnvironmentKeyPathsRemainAvailable() throws {
+        let legibilityWeightKeyPath: WritableKeyPath<EnvironmentValues, LegibilityWeight?> = \.legibilityWeight
+        let colorSchemeContrastKeyPath: WritableKeyPath<EnvironmentValues, ColorSchemeContrast> = \.colorSchemeContrast
+        let reduceMotionKeyPath: WritableKeyPath<EnvironmentValues, Bool> = \.accessibilityReduceMotion
+        let voiceOverKeyPath: WritableKeyPath<EnvironmentValues, Bool> = \.accessibilityVoiceOverEnabled
+
+        XCTAssertEqual("legibilityWeight", EnvironmentValues.key(for: legibilityWeightKeyPath))
+        XCTAssertEqual("colorSchemeContrast", EnvironmentValues.key(for: colorSchemeContrastKeyPath))
+        XCTAssertEqual("accessibilityReduceMotion", EnvironmentValues.key(for: reduceMotionKeyPath))
+        XCTAssertEqual("accessibilityVoiceOverEnabled", EnvironmentValues.key(for: voiceOverKeyPath))
+    }
+
+    func testEnvironmentBuiltinsBridgeTypedAccessibilityAndContrastValues() throws {
+        XCTAssertEqual(EnvironmentValues.bridgeBuiltin(key: "accessibilityReduceMotion", value: true) as? Bool, true)
+        XCTAssertEqual(EnvironmentValues.builtin(key: "accessibilityReduceMotion", bridgedValue: true) as? Bool, true)
+
+        XCTAssertEqual(
+            EnvironmentValues.bridgeBuiltin(key: "colorSchemeContrast", value: ColorSchemeContrast.increased) as? Int,
+            ColorSchemeContrast.increased.rawValue
+        )
+        XCTAssertEqual(
+            EnvironmentValues.builtin(key: "colorSchemeContrast", bridgedValue: ColorSchemeContrast.increased.rawValue) as? ColorSchemeContrast,
+            .increased
+        )
+
+        let bridgedLegibilityWeight = EnvironmentValues.bridgeBuiltin(key: "legibilityWeight", value: LegibilityWeight.bold)
+        XCTAssertEqual(
+            EnvironmentValues.builtin(key: "legibilityWeight", bridgedValue: bridgedLegibilityWeight) as? LegibilityWeight,
+            .bold
+        )
+    }
+    #endif
 }


### PR DESCRIPTION
Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Codex generated the code, manual testing via a sandbox native app
-----




## Summary

- This change has a SkipUI dependency: https://github.com/skiptools/skip-ui/pull/457
- Expose SkipUI simultaneous gesture support through SkipFuseUI/SkipSwiftUI bridging.
- Add typed bridge coverage for the related gesture mask path and Android overscroll pull-down hook.


## API Shape

```swift
extension View {
    public func simultaneousGesture<T>(_ gesture: T, including mask: GestureMask) -> some View where T: Gesture
    public func simultaneousGesture<T>(_ gesture: T, isEnabled: Bool) -> some View where T: Gesture
    nonisolated public func androidVerticalOverscrollPullDown(
        isEnabled: Bool,
        onPull: @escaping (CGFloat) -> Void,
        onEnd: @escaping () -> Void
    ) -> some View
}

public struct GestureMask: OptionSet {
    public static let none = GestureMask(rawValue: 0)
}
```

## Usage Example

```swift
content
    .simultaneousGesture(
        DragGesture().onChanged { _ in
            observedDragCount += 1
        }
    )
```

## Testing

- `swift test`
- Sandbox app test on android + ios (see android screen capture)

## Notes

- This PR is stacked on the SkipUI simultaneous gesture branch. `Package.swift` currently points at `https://github.com/tifroz/skip-ui.git`, branch `simultaneousGesture_support`, so the dependency should be switched back to a released `source.skip.tools/skip-ui.git` version after the SkipUI PR lands/releases.



