### PR TITLE
Fix infinite recursion in AccessibilityTraits/Technologies init()

### DIFF
--- a/Sources/SkipSwiftUI/System/Accessibility.swift
+++ b/Sources/SkipSwiftUI/System/Accessibility.swift
@@ -862,7 +862,7 @@ public struct AccessibilitySystemRotor : Sendable {
     }
 }
 
-public struct AccessibilityTechnologies : SetAlgebra, Sendable, OptionSet /* Added OptionSet conformance */ {
+public struct AccessibilityTechnologies : OptionSet, Sendable {
     public static let voiceOver = AccessibilityTechnologies(rawValue: 1 << 0)
     public static let switchControl = AccessibilityTechnologies(rawValue: 1 << 1)
 
@@ -873,7 +873,7 @@ public struct AccessibilityTechnologies : SetAlgebra, Sendable, OptionSet /* Add
     }
 
     public init() {
-        self = []
+        self.init(rawValue: 0)
     }
 }
 
@@ -888,7 +888,7 @@ public struct AccessibilityTextContentType : Sendable {
     public static let wordProcessing = AccessibilityTextContentType()
 }
 
-public struct AccessibilityTraits : SetAlgebra, OptionSet /* Added OptionSet conformance */, Sendable {
+public struct AccessibilityTraits : OptionSet, Sendable {
     public let rawValue: Int
 
     public init(rawValue: Int) {
@@ -896,7 +896,7 @@ public struct AccessibilityTraits : SetAlgebra, OptionSet /* Added OptionSet con
     }
 
     public init() {
-        self = []
+        self.init(rawValue: 0)
     }
 
     public static let isButton = AccessibilityTraits(rawValue: 1 << 0) // For bridging

--- a/Tests/SkipSwiftUITests/SkipSwiftUITests.swift
+++ b/Tests/SkipSwiftUITests/SkipSwiftUITests.swift
@@ -11,6 +11,15 @@ final class SkipSwiftUITests: XCTestCase {
     }
 
     #if !SKIP
+    func testAccessibilityOptionSetEmptyInitDoesNotRecurse() throws {
+        // `init() { self = [] }` recursed infinitely: for an OptionSet, `[]` is built
+        // via `init()`. `init(rawValue: 0)` breaks the cycle (issue #130).
+        XCTAssertEqual(AccessibilityTraits().rawValue, 0)
+        XCTAssertEqual(AccessibilityTechnologies().rawValue, 0)
+        // OptionSet semantics still work without the redundant SetAlgebra conformance.
+        XCTAssertTrue(AccessibilityTraits([.isButton, .isHeader]).contains(.isButton))
+    }
+
     func testTypedEnvironmentKeyPathsRemainAvailable() throws {
         let legibilityWeightKeyPath: WritableKeyPath<EnvironmentValues, LegibilityWeight?> = \.legibilityWeight
         let colorSchemeContrastKeyPath: WritableKeyPath<EnvironmentValues, ColorSchemeContrast> = \.colorSchemeContrast


### PR DESCRIPTION
## Motivation

`accessibilityAddTraits([.isButton, .isSelected])` — the idiomatic SwiftUI spelling — crashes with a stack overflow (SIGSEGV) on Android on first render (#130). A single trait (`.isButton`) is fine; only the array literal crashes.

## Root cause

`AccessibilityTraits` and `AccessibilityTechnologies` both declared:

```swift
public init() {
    self = []
}
```

For an `OptionSet`, `self = []` is an empty **array literal**, which resolves through `ExpressibleByArrayLiteral.init(arrayLiteral:)` → `SetAlgebra.init<S: Sequence>(_:)` → `self.init()` → `self = []` → … The initializer is **infinitely self-recursive**.

This exactly explains the reported signature:

- `.accessibilityAddTraits(.isButton)` uses a static `let` (`init(rawValue:)`) — never calls `init()` — ✅
- `.accessibilityAddTraits([.isButton, .isSelected])` — the non-empty array literal's init calls the empty `init()` — 💥

On the Android Swift runtime the recursion is through the generic `SetAlgebra`/`Sequence` machinery, so the overflow surfaces inside `__swift_instantiateGenericMetadata` (as in the reporter's tombstone) rather than in a plain `init` frame — but the trigger and fix are the same.

The redundant `SetAlgebra` conformance (these were the only two OptionSet types in the module declaring both `SetAlgebra` and `OptionSet`) is **not** the cause — see the matrix below.

## Fix

- Make `init()` non-recursive: `self.init(rawValue: 0)` (semantically identical to the empty set).
- Drop the redundant `SetAlgebra` conformance — `OptionSet` already refines it — bringing both types in line with the other ~17 OptionSet types in the module.

4 lines changed, in `Accessibility.swift`.

## Testing

Full on-device build could not be completed in this environment (local Skip toolchain is 1.9.2 while the resolved dependency set needs 1.9.4, and the cask upgrade is blocked by an unrelated broken `swiftly` post-install hook). Instead the root cause and fix were reproduced directly on the native Swift runtime with declarations copied verbatim from the (pre- and post-fix) source, isolating each variable:

| Conformance | `init()` body | `let t: T = [.a, .b]` |
|---|---|---|
| `SetAlgebra, OptionSet` | `self = []` (original) | **CRASH (SIGSEGV)** |
| `OptionSet` | `self = []` | **CRASH (SIGSEGV)** |
| `OptionSet` | *(none — uses OptionSet default)* | ✅ |
| `OptionSet` | `self.init(rawValue: 0)` (**this PR**) | ✅ |
| `SetAlgebra, OptionSet` | *(none)* | ✅ |

This reproduces the reporter's single-trait-vs-array-literal signature on native Swift, shows that removing `SetAlgebra` alone does **not** fix it (row 2), and confirms the shipped combination (row 4) resolves it. The post-fix declarations also pass the reporter's exact `accessibilityAddTraits([.isButton, .isSelected])` call plus `AccessibilityTraits()` construction and `insert`/`formUnion`.
