### PR TITLE
Forward UIApplication.shouldShowPermissionRationale(_:) from SkipUI

### DIFF
--- a/Sources/SkipSwiftUI/UIKit/UIApplication.swift
+++ b/Sources/SkipSwiftUI/UIKit/UIApplication.swift
@@ -31,6 +31,17 @@ import SkipUI
     public func requestPermission(_ permission: String) async -> Bool {
         return await application.requestPermission(permission)
     }
+
+    /// Whether the system recommends showing a rationale before requesting the given permission.
+    ///
+    /// This is `false` both when the permission has never been requested and when it has been
+    /// permanently denied, so callers that need to distinguish those cases must combine it with
+    /// their own record of having asked.
+    /// - Parameter permission: The name of the permission, such as `android.permission.RECORD_AUDIO`.
+    /// - Returns: `true` if a rationale should be shown before requesting the permission.
+    public func shouldShowPermissionRationale(_ permission: String) -> Bool {
+        return application.shouldShowPermissionRationale(permission)
+    }
     #endif
 
     @available(*, unavailable)


### PR DESCRIPTION
## Motivation

Companion to skiptools/skip-ui#498, which adds a bridgeable
`UIApplication.shouldShowPermissionRationale(_:)`. A natively-compiled SkipFuse app
sees `SkipSwiftUI.UIApplication`, not `SkipUI.UIApplication`, so the new accessor is
unreachable until this wrapper forwards it — the same way `requestPermission(_:)` and
`dynamicAndroidActivity(options:)` already do.

Without it the alternative is reaching the Activity through `AnyDynamicObject`
reflection, which additionally has to be kept on the main actor by hand or SwiftJNI
aborts the process.

## Change

```swift
public func shouldShowPermissionRationale(_ permission: String) -> Bool {
    return application.shouldShowPermissionRationale(permission)
}
```

Inside the existing `#if os(Android)` block, directly after `requestPermission(_:)`,
matching that method's shape and doc-comment style.

## Testing

`swift test` on this repo, plus an end-to-end check in a natively-compiled SkipFuse app:
the app's own JNI reflection was replaced with this call and the permission
deny → re-request path was exercised on an Android emulator.

Depends on skiptools/skip-ui#498 — this does not compile until that lands.