### PR TITLE
Added unbound DisclosureGroup constructors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         .package(url: "https://source.skip.tools/skip-bridge.git", "0.17.2"..<"2.0.0"),
         .package(url: "https://source.skip.tools/skip-android-bridge.git", "0.6.4"..<"2.0.0"),
         .package(url: "https://source.skip.tools/swift-jni.git", "0.5.0"..<"2.0.0"),
-        .package(url: "https://source.skip.tools/skip-ui.git", from: "1.59.0"),
+        .package(url: "https://github.com/fhasse95/skip-ui.git", branch: "DisclosureGroup-Bugfixes"),
     ],
     targets: [
         .target(name: "SkipFuseUI", dependencies: ["SkipSwiftUI"]),

--- a/Sources/SkipSwiftUI/Containers/DisclosureGroup.swift
+++ b/Sources/SkipSwiftUI/Containers/DisclosureGroup.swift
@@ -4,13 +4,14 @@ import SkipFuse
 import SkipUI
 
 public struct DisclosureGroup<Label, Content> where Label : View, Content : View {
-    private let isExpanded: Binding<Bool>
+    private let isExpanded: Binding<Bool>?
     private let label: Label
     private let content: Content
 
-    @available(*, unavailable)
     public init(@ViewBuilder content: @escaping () -> Content, @ViewBuilder label: () -> Label) {
-        fatalError()
+        self.isExpanded = nil
+        self.content = content()
+        self.label = label()
     }
 
     public init(isExpanded: Binding<Bool>, @ViewBuilder content: @escaping () -> Content, @ViewBuilder label: () -> Label) {
@@ -26,19 +27,21 @@ extension DisclosureGroup : View {
 
 extension DisclosureGroup : SkipUIBridging {
     public var Java_view: any SkipUI.View {
-        return SkipUI.DisclosureGroup(getExpanded: { isExpanded.wrappedValue }, setExpanded: { isExpanded.wrappedValue = $0 }, bridgedContent: content.Java_viewOrEmpty, bridgedLabel: label.Java_viewOrEmpty)
+        if let isExpanded {
+            return SkipUI.DisclosureGroup(getExpanded: { isExpanded.wrappedValue }, setExpanded: { isExpanded.wrappedValue = $0 }, bridgedContent: content.Java_viewOrEmpty, bridgedLabel: label.Java_viewOrEmpty)
+        } else {
+            return SkipUI.DisclosureGroup(bridgedContent: content.Java_viewOrEmpty, bridgedLabel: label.Java_viewOrEmpty)
+        }
     }
 }
 
 extension DisclosureGroup where Label == Text {
-    @available(*, unavailable)
     public init(_ titleKey: LocalizedStringKey, @ViewBuilder content: @escaping () -> Content) {
-        fatalError()
+        self.init(content: content, label: { Text(titleKey) })
     }
 
-    @available(*, unavailable)
     @_disfavoredOverload public init(_ titleResource: AndroidLocalizedStringResource, @ViewBuilder content: @escaping () -> Content) {
-        fatalError()
+        self.init(content: content, label: { Text(titleResource) })
     }
 
     public init(_ titleKey: LocalizedStringKey, isExpanded: Binding<Bool>, @ViewBuilder content: @escaping () -> Content) {
@@ -49,9 +52,8 @@ extension DisclosureGroup where Label == Text {
         self.init(isExpanded: isExpanded, content: content, label: { Text(titleResource) })
     }
 
-    @available(*, unavailable)
     public init<S>(_ label: S, @ViewBuilder content: @escaping () -> Content) where S : StringProtocol {
-        fatalError()
+        self.init(content: content, label: { Text(label) })
     }
 
     @_disfavoredOverload public init<S>(_ label: S, isExpanded: Binding<Bool>, @ViewBuilder content: @escaping () -> Content) where S : StringProtocol {


### PR DESCRIPTION
This PR adds the necessary code to bridge the unbound `DisclosureGroup` constructors that have been added to Skip UI.

**Parent PR:**
- https://github.com/skiptools/skip-ui/pull/507

---

Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

