### PR TITLE
Read a Color's components back through UIColor on Android

### DIFF
--- a/Sources/SkipSwiftUI/Color/Color+Conversion.swift
+++ b/Sources/SkipSwiftUI/Color/Color+Conversion.swift
@@ -1,0 +1,100 @@
+// Copyright 2025–2026 Skip
+// SPDX-License-Identifier: MPL-2.0
+
+extension Color {
+
+    static func hsbFrom(
+        r: CGFloat,
+        g: CGFloat,
+        b: CGFloat,
+    ) -> (h: CGFloat, s: CGFloat, b: CGFloat) {
+        let maximum = max(r, g, b)
+        let minimum = min(r, g, b)
+        let chroma = maximum - minimum
+
+        guard chroma > 0 else {
+            // An achromatic colour has no hue to report; UIKit reports zero for it too.
+            return (0.0, 0.0, maximum)
+        }
+
+        let sextant: Double = if maximum == r {
+            (g - b) / chroma
+        } else if maximum == g {
+            (b - r) / chroma + 2.0
+        } else {
+            (r - g) / chroma + 4.0
+        }
+
+        var hue = sextant / 6.0
+        if hue < 0.0 {
+            hue += 1.0
+        }
+
+        return (h: hue, s: maximum > 0 ? chroma / maximum : 0.0, b: maximum)
+    }
+
+    static func rgbFrom(
+        h: Double,
+        s: Double,
+        b: Double,
+    ) -> (r: Double, g: Double, b: Double) {
+        let hue = min(max(h, 0.0), 1.0) * 6.0
+        let saturation = min(max(s, 0.0), 1.0)
+        let brightness = min(max(b, 0.0), 1.0)
+
+        let chroma = brightness * saturation
+        let secondary = chroma * (1.0 - abs(hue.truncatingRemainder(dividingBy: 2.0) - 1.0))
+        let base = brightness - chroma
+
+        let rgb: (Double, Double, Double) = switch Int(hue) {
+        case 0: (chroma, secondary, 0.0)
+        case 1: (secondary, chroma, 0.0)
+        case 2: (0.0, chroma, secondary)
+        case 3: (0.0, secondary, chroma)
+        case 4: (secondary, 0.0, chroma)
+        default: (chroma, 0.0, secondary)
+        }
+
+        return (r: rgb.0 + base, g: rgb.1 + base, b: rgb.2 + base)
+    }
+
+    static func appleExtendedWhiteFrom(
+        r: CGFloat,
+        g: CGFloat,
+        b: CGFloat,
+    ) -> CGFloat {
+        let toLinear: (CGFloat) -> CGFloat = { x in
+            let sign: CGFloat = x < 0 ? -1.0 : 1.0
+            let absX = abs(x)
+
+            if absX <= 0.04045 {
+                return x / 12.92
+            } else {
+                return sign * pow((absX + 0.055) / 1.055, 2.4)
+            }
+        }
+
+        let rLinear = toLinear(r)
+        let gLinear = toLinear(g)
+        let bLinear = toLinear(b)
+
+        let wR: CGFloat = 0.2225045
+        let wG: CGFloat = 0.7168787
+        let wB: CGFloat = 0.0606168
+
+        let yLinear = (rLinear * wR) + (gLinear * wG) + (bLinear * wB)
+
+        let toGammaCorrected: (CGFloat) -> CGFloat = { y in
+            let sign: CGFloat = y < 0 ? -1.0 : 1.0
+            let absY = abs(y)
+
+            if absY <= 0.0031308 {
+                return y * 12.92
+            } else {
+                return sign * (1.055 * pow(absY, 1.0 / 2.4) - 0.055)
+            }
+        }
+
+        return toGammaCorrected(yLinear)
+    }
+}

--- a/Sources/SkipSwiftUI/Color/Color.swift
+++ b/Sources/SkipSwiftUI/Color/Color.swift
@@ -67,6 +67,31 @@ enum ColorType : Hashable, Sendable {
     indirect case saturate(ColorSpec, Double)
 }
 
+extension ColorSpec {
+    var rgbaComponents: (red: Double, green: Double, blue: Double, opacity: Double)? {
+        guard let components = type.rgbaComponents else {
+            return nil
+        }
+        return (components.red, components.green, components.blue, components.opacity * opacity)
+    }
+}
+
+extension ColorType {
+    var rgbaComponents: (red: Double, green: Double, blue: Double, opacity: Double)? {
+        switch self {
+        case .rgb(let red, let green, let blue, let opacity):
+            return (red, green, blue, opacity)
+        case .w(let white, let opacity):
+            return (white, white, white, opacity)
+        case .hsb(let hue, let saturation, let brightness, let opacity):
+            let (red, green, blue) = Color.rgbFrom(h: hue, s: saturation, b: brightness)
+            return (red, green, blue, opacity)
+        default:
+            return nil
+        }
+    }
+}
+
 extension Color : View {
     public typealias Body = Never
 }
@@ -226,7 +251,7 @@ extension Color {
             self.init(spec: .init(.systemBackground))
             return
         }
-        self.init(spec: .init(.rgb(Double(uiColor.red), Double(uiColor.green), Double(uiColor.blue), Double(uiColor.alpha))))
+        self.init(spec: uiColor.colorSpec)
     }
 }
 

--- a/Sources/SkipSwiftUI/UIKit/UIColor.swift
+++ b/Sources/SkipSwiftUI/UIKit/UIColor.swift
@@ -10,10 +10,7 @@ open class UIColor : NSObject /*, NSSecureCoding, NSCopying */, @unchecked Senda
     let uiColor: SkipUI.UIColor
 
     /// Stored RGB components for Color conversion; SkipUI.UIColor properties may be internal when bridged.
-    private let _red: CGFloat
-    private let _green: CGFloat
-    private let _blue: CGFloat
-    private let _alpha: CGFloat
+    private let _components: (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)?
 
     @available(*, unavailable)
     public init(white: CGFloat, alpha: CGFloat) {
@@ -27,20 +24,46 @@ open class UIColor : NSObject /*, NSSecureCoding, NSCopying */, @unchecked Senda
 
     public init(red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
         self.uiColor = SkipUI.UIColor(red: red, green: green, blue: blue, alpha: alpha)
-        self._red = red
-        self._green = green
-        self._blue = blue
-        self._alpha = alpha
+        self._components = (red, green, blue, alpha)
+    }
+
+    public convenience init(_ color: Color) {
+        // Extension point: only colours built from literal component values have components
+        // here. The semantic colours, the asset-catalogue colours and `saturate` resolve
+        // through MaterialTheme, the asset catalogue or the draw pass inside a @Composable,
+        // so `rgbaComponents` is nil for them and they arrive as no components at all rather
+        // than as an approximation.
+        //
+        // Such a colour cannot be carried across faithfully today because `SkipUI.UIColor`
+        // exposes a single `init(red:green:blue:alpha:)` and has no way to describe a
+        // semantic, asset-catalogue or pattern colour. There is no value we could hand it
+        // that would render correctly, so it gets opaque black and `_components` stays nil,
+        // which is what makes the getters refuse instead of reporting black as the answer.
+        // The black stand-in is inert as long as nothing reads the bridged `uiColor`; it
+        // becomes visible the moment a `UIColor` is passed on to a SkipUI API.
+        //
+        // When `SkipUI.UIColor` can represent more than sRGB components, this initializer
+        // should hand the matching representation across instead of flattening every colour
+        // to RGBA, and `_components` should stay nil only for the colours that genuinely
+        // have no components outside a composition.
+        self.init(components: color.spec.rgbaComponents.map {
+            (red  : CGFloat($0.red),
+             green: CGFloat($0.green),
+             blue : CGFloat($0.blue),
+             alpha: CGFloat($0.opacity))
+        })
+    }
+
+    private init(components: (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)?) {
+        self.uiColor = SkipUI.UIColor(red: components?.red ?? 0,
+                                      green: components?.green ?? 0,
+                                      blue: components?.blue ?? 0,
+                                      alpha: components?.alpha ?? 1)
+        self._components = components
     }
 
     /// Semantic system background color. Use with `Color(.systemBackground)` to get the adaptive semantic color.
     public static let systemBackground: UIColor = UIColor(red: 1, green: 1, blue: 1, alpha: 1)
-
-    /// RGB component accessors for Color conversion (e.g. Color(uiColor)).
-    public var red: CGFloat { _red }
-    public var green: CGFloat { _green }
-    public var blue: CGFloat { _blue }
-    public var alpha: CGFloat { _alpha }
 
     @available(*, unavailable)
     public init(displayP3Red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
@@ -152,19 +175,49 @@ open class UIColor : NSObject /*, NSSecureCoding, NSCopying */, @unchecked Senda
         fatalError()
     }
 
-    @available(*, unavailable)
-    open func getWhite(_ white: UnsafeMutablePointer<CGFloat>?, alpha: UnsafeMutablePointer<CGFloat>?) -> Bool {
-        fatalError()
+    open func getWhite(
+        _ white: UnsafeMutablePointer<CGFloat>?,
+        alpha: UnsafeMutablePointer<CGFloat>?,
+    ) -> Bool {
+        guard let components = _components else {
+            return false
+        }
+        white?.pointee = Color.appleExtendedWhiteFrom(r: components.red, g: components.green, b: components.blue)
+        alpha?.pointee = components.alpha
+        return true
     }
 
-    @available(*, unavailable)
-    open func getHue(_ hue: UnsafeMutablePointer<CGFloat>?, saturation: UnsafeMutablePointer<CGFloat>?, brightness: UnsafeMutablePointer<CGFloat>?, alpha: UnsafeMutablePointer<CGFloat>?) -> Bool {
-        fatalError()
+    open func getHue(
+        _ hue: UnsafeMutablePointer<CGFloat>?,
+        saturation: UnsafeMutablePointer<CGFloat>?,
+        brightness: UnsafeMutablePointer<CGFloat>?,
+        alpha: UnsafeMutablePointer<CGFloat>?,
+    ) -> Bool {
+        guard let components = _components else {
+            return false
+        }
+        let hsb = Color.hsbFrom(r: components.red, g: components.green, b: components.blue)
+        hue?.pointee = hsb.h
+        saturation?.pointee = hsb.s
+        brightness?.pointee = hsb.b
+        alpha?.pointee = components.alpha
+        return true
     }
 
-    @available(*, unavailable)
-    open func getRed(_ red: UnsafeMutablePointer<CGFloat>?, green: UnsafeMutablePointer<CGFloat>?, blue: UnsafeMutablePointer<CGFloat>?, alpha: UnsafeMutablePointer<CGFloat>?) -> Bool {
-        fatalError()
+    open func getRed(
+        _ red: UnsafeMutablePointer<CGFloat>?,
+        green: UnsafeMutablePointer<CGFloat>?,
+        blue: UnsafeMutablePointer<CGFloat>?,
+        alpha: UnsafeMutablePointer<CGFloat>?,
+    ) -> Bool {
+        guard let components = _components else {
+            return false
+        }
+        red?.pointee = components.red
+        green?.pointee = components.green
+        blue?.pointee = components.blue
+        alpha?.pointee = components.alpha
+        return true
     }
 
     @available(*, unavailable)
@@ -181,4 +234,35 @@ open class UIColor : NSObject /*, NSSecureCoding, NSCopying */, @unchecked Senda
     open var ciColor: Any /* CIColor */ {
         fatalError()
     }
+}
+
+// MARK: -
+
+extension UIColor {
+
+    var colorSpec: ColorSpec {
+        // Extension point: this always answers with `.rgb`, because sRGB components are the
+        // only thing a `UIColor` can describe here. A colour with no components — one that
+        // came from a semantic or asset-catalogue `Color` — therefore comes back as opaque
+        // black, and `Color -> UIColor -> Color` loses what it was.
+        //
+        // The fix is deliberately not to store the originating `ColorSpec` on `UIColor`.
+        // `ColorSpec` is `Color`'s own representation, and a UIKit type carrying a SwiftUI
+        // type's internals inverts the layering: `UIColor` is meant to be the lower of the
+        // two. It would also only paper over the loss, since the bridged `uiColor` would
+        // still be black.
+        //
+        // The fix belongs in what a `UIColor` can represent. Once it can describe more than
+        // sRGB components, map that representation onto the matching `ColorType` here — the
+        // semantic cases, `.named` for an asset-catalogue colour, `.systemBackground`, a
+        // pattern case — rather than always `.rgb`. At that point `Color` and `UIColor` can
+        // express the same set of colours and the round trip becomes lossless in both
+        // directions.
+        let r = Double(_components?.red ?? 0)
+        let g = Double(_components?.green ?? 0)
+        let b = Double(_components?.blue ?? 0)
+        let a = Double(_components?.alpha ?? 1)
+        return .init(.rgb(r, g, b, a))
+    }
+
 }

--- a/Tests/SkipSwiftUITests/ColorComponentsTests.swift
+++ b/Tests/SkipSwiftUITests/ColorComponentsTests.swift
@@ -1,0 +1,357 @@
+// Copyright 2025–2026 Skip
+// SPDX-License-Identifier: MPL-2.0
+import XCTest
+#if !SKIP
+@testable import SkipSwiftUI
+#endif
+
+final class ColorComponentsTests: XCTestCase {
+
+    #if !SKIP
+
+    func testRGBSpecReportsItsComponentsUnchanged() throws {
+        let components = try XCTUnwrap(ColorSpec(.rgb(0.25, 0.5, 0.75, 0.5)).rgbaComponents)
+
+        XCTAssertEqual(components.red, 0.25, accuracy: 0.0001)
+        XCTAssertEqual(components.green, 0.5, accuracy: 0.0001)
+        XCTAssertEqual(components.blue, 0.75, accuracy: 0.0001)
+        XCTAssertEqual(components.opacity, 0.5, accuracy: 0.0001)
+    }
+
+    func testWhiteSpecForwardsWhiteToEveryChannel() throws {
+        let components = try XCTUnwrap(ColorSpec(.w(0.4, 0.5)).rgbaComponents)
+
+        XCTAssertEqual(components.red, 0.4, accuracy: 0.0001)
+        XCTAssertEqual(components.green, 0.4, accuracy: 0.0001)
+        XCTAssertEqual(components.blue, 0.4, accuracy: 0.0001)
+        XCTAssertEqual(components.opacity, 0.5, accuracy: 0.0001)
+    }
+
+    func testSpecOpacityMultipliesTheComponentOpacity() throws {
+        let components = try XCTUnwrap(ColorSpec(.rgb(1, 0, 0, 0.5), opacity: 0.5).rgbaComponents)
+
+        XCTAssertEqual(components.red, 1, accuracy: 0.0001)
+        XCTAssertEqual(components.opacity, 0.25, accuracy: 0.0001)
+    }
+
+    func testHSBSpecConvertsEverySextantToRGB() throws {
+        let cases: [(hue: Double, expected: (Double, Double, Double))] = [
+            (0.0, (1, 0, 0)),
+            (1.0 / 6.0, (1, 1, 0)),
+            (1.0 / 3.0, (0, 1, 0)),
+            (0.5, (0, 1, 1)),
+            (2.0 / 3.0, (0, 0, 1)),
+            (5.0 / 6.0, (1, 0, 1)),
+            (1.0, (1, 0, 0)),
+        ]
+
+        for (hue, expected) in cases {
+            let components = try XCTUnwrap(ColorSpec(.hsb(hue, 1, 1, 1)).rgbaComponents)
+
+            XCTAssertEqual(components.red, expected.0, accuracy: 0.0001, "hue \(hue)")
+            XCTAssertEqual(components.green, expected.1, accuracy: 0.0001, "hue \(hue)")
+            XCTAssertEqual(components.blue, expected.2, accuracy: 0.0001, "hue \(hue)")
+        }
+    }
+
+    func testHSBSpecClampsOutOfRangeInput() throws {
+        let above = try XCTUnwrap(ColorSpec(.hsb(2.0, 2.0, 2.0, 1)).rgbaComponents)
+
+        XCTAssertEqual(above.red, 1, accuracy: 0.0001)
+        XCTAssertEqual(above.green, 0, accuracy: 0.0001)
+        XCTAssertEqual(above.blue, 0, accuracy: 0.0001)
+
+        let below = try XCTUnwrap(ColorSpec(.hsb(-1.0, -1.0, -1.0, 1)).rgbaComponents)
+
+        XCTAssertEqual(below.red, 0, accuracy: 0.0001)
+        XCTAssertEqual(below.green, 0, accuracy: 0.0001)
+        XCTAssertEqual(below.blue, 0, accuracy: 0.0001)
+    }
+
+    func testCompositionResolvedSpecsHaveNoComponents() {
+        let types: [ColorType] = [
+            .accent, .primary, .secondary,
+            .red, .orange, .yellow, .green, .mint, .teal, .cyan,
+            .blue, .indigo, .purple, .pink, .brown,
+            .white, .gray, .black, .clear,
+            .named("Brand", nil),
+            .systemBackground,
+            .saturate(ColorSpec(.rgb(1, 0, 0, 1)), 1.5),
+        ]
+
+        for type in types {
+            XCTAssertNil(ColorSpec(type).rgbaComponents, "\(type) should not claim components")
+            XCTAssertNil(ColorSpec(type, opacity: 0.5).rgbaComponents, "\(type) should not claim components")
+        }
+    }
+
+    func testHSBFromInvertsRGBFromAroundTheWheel() {
+        for step in 0..<12 {
+            let hue = Double(step) / 12.0
+            let rgb = Color.rgbFrom(h: hue, s: 1, b: 1)
+            let hsb = Color.hsbFrom(r: rgb.r, g: rgb.g, b: rgb.b)
+
+            XCTAssertEqual(hsb.h, hue, accuracy: 0.0001, "hue \(hue)")
+            XCTAssertEqual(hsb.s, 1, accuracy: 0.0001, "hue \(hue)")
+            XCTAssertEqual(hsb.b, 1, accuracy: 0.0001, "hue \(hue)")
+        }
+    }
+
+    func testHSBFromReportsNoHueOrSaturationForGreys() {
+        let hsb = Color.hsbFrom(r: 0.6, g: 0.6, b: 0.6)
+
+        XCTAssertEqual(hsb.h, 0, accuracy: 0.0001)
+        XCTAssertEqual(hsb.s, 0, accuracy: 0.0001)
+        XCTAssertEqual(hsb.b, 0.6, accuracy: 0.0001)
+    }
+
+    func testHSBFromReportsZeroBrightnessForBlack() {
+        let hsb = Color.hsbFrom(r: 0, g: 0, b: 0)
+
+        XCTAssertEqual(hsb.h, 0, accuracy: 0.0001)
+        XCTAssertEqual(hsb.s, 0, accuracy: 0.0001)
+        XCTAssertEqual(hsb.b, 0, accuracy: 0.0001)
+    }
+
+    func testAppleExtendedWhiteMatchesAppleGrayConversion() {
+        XCTAssertEqual(Color.appleExtendedWhiteFrom(r: 1, g: 0, b: 0), 0.509031, accuracy: 0.0001)
+        XCTAssertEqual(Color.appleExtendedWhiteFrom(r: 0, g: 1, b: 0), 0.863387, accuracy: 0.0001)
+        XCTAssertEqual(Color.appleExtendedWhiteFrom(r: 0, g: 0, b: 1), 0.273079, accuracy: 0.0001)
+        XCTAssertEqual(Color.appleExtendedWhiteFrom(r: 0.25, g: 0.5, b: 0.75), 0.480501, accuracy: 0.0001)
+    }
+
+    func testAppleExtendedWhitePreservesGreys() {
+        XCTAssertEqual(Color.appleExtendedWhiteFrom(r: 0.3, g: 0.3, b: 0.3), 0.3, accuracy: 0.0001)
+        XCTAssertEqual(Color.appleExtendedWhiteFrom(r: 0.02, g: 0.02, b: 0.02), 0.02, accuracy: 0.0001)
+        XCTAssertEqual(Color.appleExtendedWhiteFrom(r: 0, g: 0, b: 0), 0, accuracy: 0.0001)
+        XCTAssertEqual(Color.appleExtendedWhiteFrom(r: 1, g: 1, b: 1), 1, accuracy: 0.0001)
+    }
+
+    func testAppleExtendedWhiteHandlesExtendedRangeComponents() {
+        XCTAssertEqual(Color.appleExtendedWhiteFrom(r: -0.2, g: 0, b: 0), -0.081332, accuracy: 0.0001)
+        XCTAssertEqual(Color.appleExtendedWhiteFrom(r: -0.02, g: -0.02, b: -0.02), -0.02, accuracy: 0.0001)
+    }
+
+    func testGetRedReadsBackLiteralComponents() throws {
+        let color = SkipSwiftUI.UIColor(SkipSwiftUI.Color(red: 0.25, green: 0.5, blue: 0.75, opacity: 0.5))
+        var r: CGFloat = -1, g: CGFloat = -1, b: CGFloat = -1, a: CGFloat = -1
+
+        XCTAssertTrue(color.getRed(&r, green: &g, blue: &b, alpha: &a))
+        XCTAssertEqual(r, 0.25, accuracy: 0.0001)
+        XCTAssertEqual(g, 0.5, accuracy: 0.0001)
+        XCTAssertEqual(b, 0.75, accuracy: 0.0001)
+        XCTAssertEqual(a, 0.5, accuracy: 0.0001)
+    }
+
+    func testGetRedReadsBackTheRGBAInitializer() throws {
+        let color = SkipSwiftUI.UIColor(red: 0.1, green: 0.2, blue: 0.3, alpha: 0.4)
+        var r: CGFloat = -1, g: CGFloat = -1, b: CGFloat = -1, a: CGFloat = -1
+
+        XCTAssertTrue(color.getRed(&r, green: &g, blue: &b, alpha: &a))
+        XCTAssertEqual(r, 0.1, accuracy: 0.0001)
+        XCTAssertEqual(g, 0.2, accuracy: 0.0001)
+        XCTAssertEqual(b, 0.3, accuracy: 0.0001)
+        XCTAssertEqual(a, 0.4, accuracy: 0.0001)
+    }
+
+    func testOpacityModifierCompoundsIntoAlpha() throws {
+        let color = SkipSwiftUI.UIColor(SkipSwiftUI.Color(red: 1, green: 0, blue: 0, opacity: 0.5).opacity(0.5))
+        var r: CGFloat = -1, g: CGFloat = -1, b: CGFloat = -1, a: CGFloat = -1
+
+        XCTAssertTrue(color.getRed(&r, green: &g, blue: &b, alpha: &a))
+        XCTAssertEqual(r, 1, accuracy: 0.0001)
+        XCTAssertEqual(a, 0.25, accuracy: 0.0001)
+    }
+
+    func testWhiteForwardsToEveryChannel() throws {
+        let color = SkipSwiftUI.UIColor(SkipSwiftUI.Color(white: 0.4))
+        var r: CGFloat = -1, g: CGFloat = -1, b: CGFloat = -1, a: CGFloat = -1
+
+        XCTAssertTrue(color.getRed(&r, green: &g, blue: &b, alpha: &a))
+        XCTAssertEqual(r, 0.4, accuracy: 0.0001)
+        XCTAssertEqual(g, 0.4, accuracy: 0.0001)
+        XCTAssertEqual(b, 0.4, accuracy: 0.0001)
+        XCTAssertEqual(a, 1, accuracy: 0.0001)
+    }
+
+    func testHueSaturationBrightnessConvertsToRGB() throws {
+        // Primaries sit at hue 0, 1/3 and 2/3 of the way round the wheel.
+        let cases: [(hue: Double, expected: (CGFloat, CGFloat, CGFloat))] = [
+            (0.0, (1, 0, 0)),
+            (1.0 / 3.0, (0, 1, 0)),
+            (2.0 / 3.0, (0, 0, 1)),
+        ]
+
+        for (hue, expected) in cases {
+            let color = SkipSwiftUI.UIColor(SkipSwiftUI.Color(hue: hue, saturation: 1, brightness: 1))
+            var r: CGFloat = -1, g: CGFloat = -1, b: CGFloat = -1, a: CGFloat = -1
+
+            XCTAssertTrue(color.getRed(&r, green: &g, blue: &b, alpha: &a))
+            XCTAssertEqual(r, expected.0, accuracy: 0.0001, "hue \(hue)")
+            XCTAssertEqual(g, expected.1, accuracy: 0.0001, "hue \(hue)")
+            XCTAssertEqual(b, expected.2, accuracy: 0.0001, "hue \(hue)")
+        }
+    }
+
+    func testGreyBrightnessHasNoChroma() throws {
+        let color = SkipSwiftUI.UIColor(SkipSwiftUI.Color(hue: 0.5, saturation: 0, brightness: 0.6))
+        var r: CGFloat = -1, g: CGFloat = -1, b: CGFloat = -1, a: CGFloat = -1
+
+        XCTAssertTrue(color.getRed(&r, green: &g, blue: &b, alpha: &a))
+        XCTAssertEqual(r, 0.6, accuracy: 0.0001)
+        XCTAssertEqual(g, 0.6, accuracy: 0.0001)
+        XCTAssertEqual(b, 0.6, accuracy: 0.0001)
+    }
+
+    func testGetHueInvertsTheHSBConversion() throws {
+        let cases: [(hue: Double, saturation: Double, brightness: Double)] = [
+            (0.0, 1.0, 1.0),
+            (1.0 / 3.0, 1.0, 1.0),
+            (2.0 / 3.0, 0.5, 0.75),
+            (0.125, 0.9, 0.4),
+            (0.875, 0.25, 1.0),
+        ]
+
+        for expected in cases {
+            let color = SkipSwiftUI.UIColor(SkipSwiftUI.Color(hue: expected.hue, saturation: expected.saturation, brightness: expected.brightness))
+            var h: CGFloat = -1, s: CGFloat = -1, b: CGFloat = -1, a: CGFloat = -1
+
+            XCTAssertTrue(color.getHue(&h, saturation: &s, brightness: &b, alpha: &a))
+            XCTAssertEqual(h, expected.hue, accuracy: 0.0001, "hue for \(expected)")
+            XCTAssertEqual(s, expected.saturation, accuracy: 0.0001, "saturation for \(expected)")
+            XCTAssertEqual(b, expected.brightness, accuracy: 0.0001, "brightness for \(expected)")
+            XCTAssertEqual(a, 1, accuracy: 0.0001)
+        }
+    }
+
+    func testGetHueReportsNoHueForAnAchromaticColour() throws {
+        let color = SkipSwiftUI.UIColor(SkipSwiftUI.Color(white: 0.6))
+        var h: CGFloat = -1, s: CGFloat = -1, b: CGFloat = -1, a: CGFloat = -1
+
+        XCTAssertTrue(color.getHue(&h, saturation: &s, brightness: &b, alpha: &a))
+        XCTAssertEqual(h, 0, accuracy: 0.0001)
+        XCTAssertEqual(s, 0, accuracy: 0.0001)
+        XCTAssertEqual(b, 0.6, accuracy: 0.0001)
+    }
+
+    func testGetHueCarriesAlphaThrough() throws {
+        let color = SkipSwiftUI.UIColor(SkipSwiftUI.Color(red: 1, green: 0, blue: 0, opacity: 0.25))
+        var h: CGFloat = -1, s: CGFloat = -1, b: CGFloat = -1, a: CGFloat = -1
+
+        XCTAssertTrue(color.getHue(&h, saturation: &s, brightness: &b, alpha: &a))
+        XCTAssertEqual(a, 0.25, accuracy: 0.0001)
+    }
+
+    func testGetWhiteReadsAGreyBackUnchanged() throws {
+        var w: CGFloat = -1, a: CGFloat = -1
+
+        XCTAssertTrue(SkipSwiftUI.UIColor(SkipSwiftUI.Color(white: 0.3, opacity: 0.5)).getWhite(&w, alpha: &a))
+        XCTAssertEqual(w, 0.3, accuracy: 0.0001)
+        XCTAssertEqual(a, 0.5, accuracy: 0.0001)
+    }
+
+    func testGetWhiteConvertsAChromaticColourToItsAppleGrey() throws {
+        var w: CGFloat = -1, a: CGFloat = -1
+
+        XCTAssertTrue(SkipSwiftUI.UIColor(SkipSwiftUI.Color(red: 1, green: 0, blue: 0)).getWhite(&w, alpha: &a))
+        XCTAssertEqual(w, 0.509031, accuracy: 0.0001)
+        XCTAssertEqual(a, 1, accuracy: 0.0001)
+    }
+
+    func testCompositionResolvedColoursReportNoComponents() throws {
+        // These resolve through MaterialTheme or the asset catalogue inside a @Composable,
+        // so there is nothing to read outside one — and nothing may be written back.
+        let colors: [SkipSwiftUI.Color] = [
+            .red,
+            .primary,
+            .accentColor,
+            SkipSwiftUI.Color("Brand"),
+            SkipSwiftUI.Color(spec: .init(.saturate(ColorSpec(.rgb(1, 0, 0, 1)), 1.5))),
+        ]
+
+        for color in colors {
+            var r: CGFloat = -1, g: CGFloat = -1, b: CGFloat = -1, a: CGFloat = -1
+
+            XCTAssertFalse(SkipSwiftUI.UIColor(color).getRed(&r, green: &g, blue: &b, alpha: &a),
+                           "\(color) should not claim components")
+            XCTAssertEqual(r, -1, "pointers must be left untouched on failure")
+            XCTAssertEqual(g, -1)
+            XCTAssertEqual(b, -1)
+            XCTAssertEqual(a, -1)
+        }
+    }
+
+    func testComponentReadersAllRefuseCompositionResolvedColours() throws {
+        let color = SkipSwiftUI.UIColor(SkipSwiftUI.Color.primary)
+        var x: CGFloat = -1, y: CGFloat = -1, z: CGFloat = -1, w: CGFloat = -1
+
+        XCTAssertFalse(color.getRed(&x, green: &y, blue: &z, alpha: &w))
+        XCTAssertFalse(color.getHue(&x, saturation: &y, brightness: &z, alpha: &w))
+        XCTAssertFalse(color.getWhite(&x, alpha: &y))
+
+        XCTAssertEqual(x, -1, "pointers must be left untouched on failure")
+        XCTAssertEqual(y, -1)
+        XCTAssertEqual(z, -1)
+        XCTAssertEqual(w, -1)
+    }
+
+    func testComponentReadersAcceptNilPointers() throws {
+        let readable = SkipSwiftUI.UIColor(SkipSwiftUI.Color(red: 1, green: 0, blue: 0))
+
+        XCTAssertTrue(readable.getRed(nil, green: nil, blue: nil, alpha: nil))
+        XCTAssertTrue(readable.getHue(nil, saturation: nil, brightness: nil, alpha: nil))
+        XCTAssertTrue(readable.getWhite(nil, alpha: nil))
+
+        let unreadable = SkipSwiftUI.UIColor(SkipSwiftUI.Color.primary)
+
+        XCTAssertFalse(unreadable.getRed(nil, green: nil, blue: nil, alpha: nil))
+        XCTAssertFalse(unreadable.getHue(nil, saturation: nil, brightness: nil, alpha: nil))
+        XCTAssertFalse(unreadable.getWhite(nil, alpha: nil))
+    }
+
+    func testLiteralColoursKeepTheirComponentsThroughTheUIColorRoundTrip() throws {
+        let colors: [SkipSwiftUI.Color] = [
+            SkipSwiftUI.Color(red: 0.1, green: 0.2, blue: 0.3),
+            SkipSwiftUI.Color(white: 0.4).opacity(0.5),
+            SkipSwiftUI.Color(hue: 0.25, saturation: 0.6, brightness: 0.8, opacity: 0.75),
+        ]
+
+        for color in colors {
+            let expected = try XCTUnwrap(color.spec.rgbaComponents)
+            let actual = try XCTUnwrap(SkipSwiftUI.Color(SkipSwiftUI.UIColor(color)).spec.rgbaComponents)
+
+            XCTAssertEqual(actual.red, expected.red, accuracy: 0.0001, "\(color)")
+            XCTAssertEqual(actual.green, expected.green, accuracy: 0.0001, "\(color)")
+            XCTAssertEqual(actual.blue, expected.blue, accuracy: 0.0001, "\(color)")
+            XCTAssertEqual(actual.opacity, expected.opacity, accuracy: 0.0001, "\(color)")
+        }
+    }
+
+    func testRGBColoursKeepTheirSpecThroughTheUIColorRoundTrip() throws {
+        let color = SkipSwiftUI.Color(red: 0.1, green: 0.2, blue: 0.3, opacity: 0.4)
+
+        XCTAssertEqual(SkipSwiftUI.Color(SkipSwiftUI.UIColor(color)), color)
+    }
+
+    func testColorFromAnRGBAUIColorKeepsItsComponents() throws {
+        let uiColor = SkipSwiftUI.UIColor(red: 0.1, green: 0.2, blue: 0.3, alpha: 0.4)
+
+        XCTAssertEqual(SkipSwiftUI.Color(uiColor), SkipSwiftUI.Color(red: 0.1, green: 0.2, blue: 0.3, opacity: 0.4))
+    }
+
+    func testCompositionResolvedColoursAreLostThroughTheUIColorRoundTrip() throws {
+        let colors: [SkipSwiftUI.Color] = [.red, .primary, .accentColor, SkipSwiftUI.Color("Brand")]
+
+        for color in colors {
+            XCTAssertEqual(SkipSwiftUI.Color(SkipSwiftUI.UIColor(color)),
+                           SkipSwiftUI.Color(spec: .init(.rgb(0, 0, 0, 1))),
+                           "\(color)")
+        }
+    }
+
+    func testSystemBackgroundStillResolvesToItsSemanticColour() throws {
+        XCTAssertEqual(SkipSwiftUI.Color(SkipSwiftUI.UIColor.systemBackground),
+                       SkipSwiftUI.Color(spec: .init(.systemBackground)))
+    }
+    #endif
+}


### PR DESCRIPTION
`Color`'s components are unreachable outside a composition today: `resolve(in:)` and `cgColor` are unavailable and `ColorSpec` is internal, so there's no way to read a color back for encoding – forming a hex string from a themed color, for
instance.

Expose them the way UIKit does, so the same call site compiles on both platforms:

- `UIColor.init(_ color: Color)`, matching SwiftUI's own `convenience` declaration
- `getRed(_:green:blue:alpha:)`, `getHue(_:saturation:brightness:alpha:)` and `getWhite(_:alpha:)`, no longer `unavailable`

### Motivation
I need a way to read RGB components to be able to convert them into a HEX-string that is used as a key for storage colors in the [theme-kit](https://github.com/rozd/theme-kit) project I'm porting to Android.

### What can be read

Colors built from literal values – `Color(red:green:blue:opacity:)`, `Color(white:opacity:)`, `Color(hue:saturation:brightness:opacity:)`, and `.opacity(_:)` over any of them. 

The HSV conversion mirrors `androidx.compose.ui.graphics.Color.hsv`, which is what SkipUI's `Color(hue:saturation:brightness:opacity:)` bridges to, including its 0…1 clamping. `getWhite` matches Apple's extended gray gamma 2.2 conversion – the expected values in the tests were measured from `NSColor.usingColorSpace(.extendedGenericGamma22Gray)` and agree to within 2×10⁻⁵.

### What can't

The system and asset-catalogue colors (`Color.red`, `Color.primary`, `Color("Brand")`) and `saturate` resolve through `MaterialTheme`, the asset catalogue, or the draw pass inside a `@Composable`. They have no components outside one, so all three getters return `false` and leave the pointers untouched, which is the same signal UIKit gives for the colors it can't express as RGBA. They carry opaque black internally, and the `Bool` result is what keeps that from being read back as if it were the answer.

### Known limitation

`Color -> UIColor -> Color` returns opaque black for those colors. `SkipUI.UIColor` only exposes `init(red:green:blue:alpha:)`, so there's no faithful representation to carry across, and storing `Color`'s internal `ColorSpec` on `UIColor` would invert the layering without fixing the bridged value. Out of scope here; documented at the two extension points where a richer `UIColor` representation would plug in, and pinned by a test so it's a stated fact rather than an absence.

No SkipUI change needed.

-----

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI was used for:
- generating tests
- reviewing the implementation
- drafting the comment messages and PR description
- improving comments for the Extension Points
- optimizing RGB<->HSB conversion functions
-----

