### PR TITLE
Add public initializer to Gradient.Stop

### DIFF
--- a/Sources/SkipSwiftUI/Graphics/Gradient.swift
+++ b/Sources/SkipSwiftUI/Graphics/Gradient.swift
@@ -9,6 +9,11 @@ import SkipUI
     @frozen public struct Stop : Hashable, Sendable {
         public var color: Color
         public var location: CGFloat
+
+        public init(color: Color, location: CGFloat) {
+            self.color = color
+            self.location = location
+        }
     }
 
     public var stops: [Gradient.Stop]


### PR DESCRIPTION
`Gradient.Stop` is a public struct with public stored properties, but its memberwise initializer is synthesized and therefore internal, so client modules cannot construct a stop directly. SwiftUI's Gradient.Stop has a public init, and skip-ui's own Stop already declares one, so this is a parity gap rather than a deliberate restriction.

Without it, building a gradient with non-uniform stop locations from another module requires constructing via `Gradient(colors:)` and then overwriting each stop's location.

----
Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.
- drafting a commit message
-----

