### PR TITLE
Added searchable isPresented support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         .package(url: "https://source.skip.tools/skip-bridge.git", "0.17.2"..<"2.0.0"),
         .package(url: "https://source.skip.tools/skip-android-bridge.git", "0.6.4"..<"2.0.0"),
         .package(url: "https://source.skip.tools/swift-jni.git", "0.5.0"..<"2.0.0"),
-        .package(path: "/Users/fabian/XCode/Skip/skip-ui"),
+        .package(url: "https://github.com/fhasse95/skip-ui.git", branch: "searchable-is-presented"),
     ],
     targets: [
         .target(name: "SkipFuseUI", dependencies: ["SkipSwiftUI"]),

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         .package(url: "https://source.skip.tools/skip-bridge.git", "0.17.2"..<"2.0.0"),
         .package(url: "https://source.skip.tools/skip-android-bridge.git", "0.6.4"..<"2.0.0"),
         .package(url: "https://source.skip.tools/swift-jni.git", "0.5.0"..<"2.0.0"),
-        .package(url: "https://source.skip.tools/skip-ui.git", from: "1.59.0"),
+        .package(path: "/Users/fabian/XCode/Skip/skip-ui"),
     ],
     targets: [
         .target(name: "SkipFuseUI", dependencies: ["SkipSwiftUI"]),

--- a/Sources/SkipSwiftUI/Commands/Search.swift
+++ b/Sources/SkipSwiftUI/Commands/Search.swift
@@ -115,24 +115,22 @@ extension View {
 }
 
 extension View {
-    @available(*, unavailable)
     nonisolated public func searchable(text: Binding<String>, isPresented: Binding<Bool>, placement: SearchFieldPlacement = .automatic, prompt: Text? = nil) -> some View {
-        stubView()
+        return ModifierView(target: self) {
+            $0.Java_viewOrEmpty.searchable(getText: text.get, setText: text.set, getIsPresented: { isPresented.wrappedValue }, setIsPresented: { isPresented.wrappedValue = $0 }, prompt: prompt?.Java_view as? SkipUI.Text)
+        }
     }
 
-    @available(*, unavailable)
     nonisolated public func searchable(text: Binding<String>, isPresented: Binding<Bool>, placement: SearchFieldPlacement = .automatic, prompt: LocalizedStringKey) -> some View {
-        stubView()
+        return searchable(text: text, isPresented: isPresented, placement: placement, prompt: Text(prompt))
     }
 
-    @available(*, unavailable)
     @_disfavoredOverload nonisolated public func searchable(text: Binding<String>, isPresented: Binding<Bool>, placement: SearchFieldPlacement = .automatic, prompt: AndroidLocalizedStringResource) -> some View {
-        stubView()
+        return searchable(text: text, isPresented: isPresented, placement: placement, prompt: Text(prompt))
     }
 
-    @available(*, unavailable)
     @_disfavoredOverload nonisolated public func searchable<S>(text: Binding<String>, isPresented: Binding<Bool>, placement: SearchFieldPlacement = .automatic, prompt: S) -> some View where S : StringProtocol {
-        stubView()
+        return searchable(text: text, isPresented: isPresented, placement: placement, prompt: Text(prompt))
     }
 }
 


### PR DESCRIPTION
This PR adds the necessary code to bridge the `searchable(text:isPresented:)` modifier that has been added to Skip UI.

**Parent PR:**
- https://github.com/skiptools/skip-ui/pull/513

---

Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

