### PR TITLE
Implement ToggleStyle protocol and bridging

### DIFF
--- a/Sources/SkipSwiftUI/Controls/Button.swift
+++ b/Sources/SkipSwiftUI/Controls/Button.swift
@@ -71,9 +71,9 @@ extension Button where Label == SkipSwiftUI.Label<Text, Image> {
 //}
 
 extension Button where Label == PrimitiveButtonStyleConfiguration.Label {
-    @available(*, unavailable)
-    public init(_ configuration: PrimitiveButtonStyleConfiguration) {
-        fatalError()
+    @preconcurrency public init(_ configuration: PrimitiveButtonStyleConfiguration) {
+        let configurationBox = UncheckedSendableBox(configuration)
+        self.init(role: configuration.role, action: { configurationBox.wrappedValue.trigger() }, label: { configuration.label })
     }
 }
 
@@ -155,13 +155,27 @@ public struct ButtonSizing : Hashable, Sendable {
 }
 
 public struct ButtonStyleConfiguration {
-    public struct Label : View {
+    public struct Label {
         public typealias Body = Never
+
+        let Java_label: any SkipUI.View
     }
 
     public let role: ButtonRole?
     public let label: ButtonStyleConfiguration.Label
     public let isPressed: Bool
+
+    init(Java_configuration: SkipUI.ButtonStyleBridgedConfiguration) {
+        self.role = Java_configuration.bridgedRole.map { ButtonRole(identifier: $0) }
+        self.label = Label(Java_label: Java_configuration.label)
+        self.isPressed = Java_configuration.isPressed
+    }
+}
+
+extension ButtonStyleConfiguration.Label : View, SkipUIBridging {
+    public var Java_view: any SkipUI.View {
+        return Java_label
+    }
 }
 
 public struct BorderedButtonStyle : PrimitiveButtonStyle {
@@ -169,7 +183,7 @@ public struct BorderedButtonStyle : PrimitiveButtonStyle {
     }
 
     @MainActor @preconcurrency public func makeBody(configuration: BorderedButtonStyle.Configuration) -> some View {
-        stubView()
+        Button(configuration).buttonStyle(self)
     }
 
     public let identifier = 3 // For bridging
@@ -180,7 +194,7 @@ public struct BorderedProminentButtonStyle : PrimitiveButtonStyle {
     }
 
     @MainActor @preconcurrency public func makeBody(configuration: BorderedProminentButtonStyle.Configuration) -> some View {
-        stubView()
+        Button(configuration).buttonStyle(self)
     }
 
     public let identifier = 4 // For bridging
@@ -191,7 +205,7 @@ public struct BorderlessButtonStyle : PrimitiveButtonStyle {
     }
 
     @MainActor @preconcurrency public func makeBody(configuration: BorderlessButtonStyle.Configuration) -> some View {
-        stubView()
+        Button(configuration).buttonStyle(self)
     }
 
     public let identifier = 2 // For bridging
@@ -202,7 +216,7 @@ public struct DefaultButtonStyle : PrimitiveButtonStyle {
     }
 
     @MainActor @preconcurrency public func makeBody(configuration: DefaultButtonStyle.Configuration) -> some View {
-        stubView()
+        Button(configuration).buttonStyle(self)
     }
 
     public let identifier = 0 // For bridging
@@ -213,7 +227,7 @@ public struct PlainButtonStyle : PrimitiveButtonStyle {
     }
 
     @MainActor @preconcurrency public func makeBody(configuration: PlainButtonStyle.Configuration) -> some View {
-        stubView()
+        Button(configuration).buttonStyle(self)
     }
 
     public let identifier = 1 // For bridging
@@ -236,7 +250,7 @@ public struct M3TextButtonStyle : PrimitiveButtonStyle {
     }
 
     @MainActor @preconcurrency public func makeBody(configuration: M3TextButtonStyle.Configuration) -> some View {
-        stubView()
+        Button(configuration).buttonStyle(self)
     }
 
     public let identifier = 7 // For bridging
@@ -302,21 +316,30 @@ extension PrimitiveButtonStyle where Self == M3TextButtonStyle {
 }
 
 public struct PrimitiveButtonStyleConfiguration {
-    public struct Label : View {
+    public struct Label {
         public typealias Body = Never
+
+        let Java_label: any SkipUI.View
     }
 
     public let role: ButtonRole?
     public let label: PrimitiveButtonStyleConfiguration.Label
+    private let Java_configuration: SkipUI.ButtonStyleBridgedConfiguration
 
-    @available(*, unavailable)
-    public init(role: ButtonRole?, label: Label) {
-        fatalError()
+    init(Java_configuration: SkipUI.ButtonStyleBridgedConfiguration) {
+        self.role = Java_configuration.bridgedRole.map { ButtonRole(identifier: $0) }
+        self.label = Label(Java_label: Java_configuration.label)
+        self.Java_configuration = Java_configuration
     }
 
-    @available(*, unavailable)
     public func trigger() {
-        fatalError()
+        Java_configuration.trigger()
+    }
+}
+
+extension PrimitiveButtonStyleConfiguration.Label : View, SkipUIBridging {
+    public var Java_view: any SkipUI.View {
+        return Java_label
     }
 }
 
@@ -332,8 +355,54 @@ extension View {
     }
 
     nonisolated public func buttonStyle<S>(_ style: S) -> some View where S : PrimitiveButtonStyle {
-        return ModifierView(target: self) {
-            $0.Java_viewOrEmpty.buttonStyle(bridgedStyle: style.identifier)
+        let identifier = style.identifier
+        let resolvedStyle = ResolvedButtonStyle(style) { style, Java_configuration in
+            style.makeBody(configuration: PrimitiveButtonStyleConfiguration(Java_configuration: Java_configuration)).Java_viewOrEmpty
         }
+        return ModifierView(target: self) {
+            guard identifier < 0 else {
+                return $0.Java_viewOrEmpty.buttonStyle(bridgedStyle: identifier)
+            }
+            return $0.Java_viewOrEmpty.buttonStyle(isPrimitive: true, environmentKeys: resolvedStyle.environmentKeys, bridgedMakeBody: resolvedStyle.makeBody(Java_configuration:))
+        }
+    }
+
+    nonisolated public func buttonStyle<S>(_ style: S) -> some View where S : ButtonStyle {
+        let resolvedStyle = ResolvedButtonStyle(style) { style, Java_configuration in
+            style.makeBody(configuration: ButtonStyleConfiguration(Java_configuration: Java_configuration)).Java_viewOrEmpty
+        }
+        return ModifierView(target: self) {
+            $0.Java_viewOrEmpty.buttonStyle(isPrimitive: false, environmentKeys: resolvedStyle.environmentKeys, bridgedMakeBody: resolvedStyle.makeBody(Java_configuration:))
+        }
+    }
+}
+
+/// A natively-compiled `ButtonStyle` or `PrimitiveButtonStyle` prepared for SkipUI.
+///
+/// SwiftUI resolves a style's dynamic properties before creating its body. Skip does not generate that resolution for
+/// styles, so the style's `@Environment` properties are synced from each button's Compose environment before its body
+/// is created.
+struct ResolvedButtonStyle<Style> : @unchecked Sendable {
+    /// The keys of the style's `@Environment` properties, which SkipUI reads at each button's position.
+    let environmentKeys: [String]
+    private let style: Style
+    private let makeStyleBody: @MainActor (Style, SkipUI.ButtonStyleBridgedConfiguration) -> any SkipUI.View
+
+    nonisolated init(_ style: Style, makeBody: @escaping @MainActor (Style, SkipUI.ButtonStyleBridgedConfiguration) -> any SkipUI.View) {
+        self.environmentKeys = Java_environmentKeys(of: style)
+        self.style = style
+        self.makeStyleBody = makeBody
+    }
+
+    /// Creates the style's body for a button.
+    ///
+    /// Styles are only used on the main thread during composition.
+    nonisolated func makeBody(Java_configuration: SkipUI.ButtonStyleBridgedConfiguration) -> any SkipUI.View {
+        let Java_configurationBox = UncheckedSendableBox(Java_configuration)
+        return assumeMainActorUnchecked {
+            let Java_configuration = Java_configurationBox.wrappedValue
+            Java_syncEnvironment(of: style) { Java_configuration.environmentSupport(forKey: $0) }
+            return UncheckedSendableBox(makeStyleBody(style, Java_configuration))
+        }.wrappedValue
     }
 }

--- a/Sources/SkipSwiftUI/Controls/Toggle.swift
+++ b/Sources/SkipSwiftUI/Controls/Toggle.swift
@@ -96,7 +96,7 @@ extension Toggle where Label == SkipSwiftUI.Label<Text, Image> {
 //
 //    public init<C>(_ titleKey: LocalizedStringKey, image: ImageResource, sources: C, isOn: KeyPath<C.Element, Binding<Bool>>) where C : RandomAccessCollection
 //
-//    public init<S, C>(_ title: S, image: ImageResource, sources: C, isOn: KeyPath<C.Element, Binding<Bool>>) where S : StringProtocol, C : RandomAccessCollection
+//    @_disfavoredOverload public init<S, C>(_ title: S, image: ImageResource, sources: C, isOn: KeyPath<C.Element, Binding<Bool>>) where S : StringProtocol, C : RandomAccessCollection
 //}
 
 @MainActor @preconcurrency public protocol ToggleStyle {

--- a/Sources/SkipSwiftUI/Properties/Environment.swift
+++ b/Sources/SkipSwiftUI/Properties/Environment.swift
@@ -39,6 +39,32 @@ import SkipUI
 //extension Environment : Sendable where Value : Sendable {
 //}
 
+/// An `@Environment` property whose value is synced from Compose by key.
+protocol EnvironmentSupportSyncable {
+    var key: String { get }
+    func Java_syncEnvironmentSupport(_ support: EnvironmentSupport?)
+}
+
+extension Environment : EnvironmentSupportSyncable {
+}
+
+/// The keys of the `@Environment` properties declared by a value that is not itself a bridged view, such as a custom style.
+func Java_environmentKeys(of value: Any) -> [String] {
+    return Mirror(reflecting: value).children.compactMap { ($0.value as? EnvironmentSupportSyncable)?.key }
+}
+
+/// Sync the `@Environment` properties declared by a value that is not itself a bridged view, such as a custom style.
+///
+/// Skip generates this syncing for `View` and `ViewModifier` types, but other types that declare `@Environment`
+/// properties must be synced manually before use, or reading the property will crash.
+func Java_syncEnvironment(of value: Any, support: (String) -> EnvironmentSupport?) {
+    for child in Mirror(reflecting: value).children {
+        if let environment = child.value as? EnvironmentSupportSyncable {
+            environment.Java_syncEnvironmentSupport(support(environment.key))
+        }
+    }
+}
+
 @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
 extension Environment {
     public init(_ objectType: Value.Type) where Value : AnyObject, Value : Observable {

--- a/Sources/SkipSwiftUISamples/Fixtures.swift
+++ b/Sources/SkipSwiftUISamples/Fixtures.swift
@@ -79,6 +79,60 @@ public struct CounterTestFixture: View {
     }
 }
 
+/// Sample: a custom `ButtonStyle` whose body reads `@Environment(\.isEnabled)` declared on the style
+/// itself, and a `PrimitiveButtonStyle` that wraps `Button(configuration)` — verifies bridged style
+/// bodies, actions routed through both style kinds, and environment syncing into non-view types.
+public struct ButtonStyleTestFixture: View {
+    @State var count = 0
+    @State var isDisabled = false
+
+    public init() {
+    }
+
+    public var body: some View {
+        VStack {
+            Text("count: \(count)")
+                .accessibilityIdentifier("style-counter-label")
+            Button("styled") {
+                count += 1
+            }
+            .buttonStyle(SampleButtonStyle())
+            .disabled(isDisabled)
+            .accessibilityIdentifier("styled-button")
+            Button("primitive") {
+                count += 10
+            }
+            .buttonStyle(SamplePrimitiveButtonStyle())
+            .accessibilityIdentifier("primitive-button")
+            Button("disable") {
+                isDisabled.toggle()
+            }
+            .accessibilityIdentifier("disable-button")
+        }
+    }
+}
+
+struct SampleButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        HStack {
+            configuration.label
+            Text(isEnabled ? "enabled" : "disabled")
+                .accessibilityIdentifier("styled-button-state")
+        }
+        .padding()
+        .opacity(configuration.isPressed ? 0.5 : 1.0)
+    }
+}
+
+struct SamplePrimitiveButtonStyle: PrimitiveButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        Button(configuration)
+            .padding()
+    }
+}
+
 /// Observable model for the `@Observable` provenance samples.
 @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
 @Observable

--- a/Tests/SkipSwiftUISamplesTests/FuseComposeUITests.swift
+++ b/Tests/SkipSwiftUISamplesTests/FuseComposeUITests.swift
@@ -97,6 +97,38 @@ final class FuseComposeUITests: XCTestCase {
         #endif
     }
 
+    /// Custom button styles through the bridge: the native style body renders around the label,
+    /// actions fire through both `ButtonStyle` and `PrimitiveButtonStyle`, and `@Environment`
+    /// values declared on the style itself track the button's environment.
+    func testCustomButtonStyles() throws {
+        #if !SKIP
+        throw XCTSkip("Compose UI testing is Android-only")
+        #else
+        try requireBridgedMainActor()
+        composeRule.setContent {
+            ButtonStyleTestFixture().Compose()
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag("styled-button-state", useUnmergedTree: true).assertTextEquals("enabled")
+
+        composeRule.onNodeWithTag("styled-button").performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag("style-counter-label").assertTextEquals("count: 1")
+
+        composeRule.onNodeWithTag("primitive-button").performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag("style-counter-label").assertTextEquals("count: 11")
+
+        composeRule.onNodeWithTag("disable-button").performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag("styled-button-state", useUnmergedTree: true).assertTextEquals("disabled")
+
+        composeRule.onNodeWithTag("styled-button").performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag("style-counter-label").assertTextEquals("count: 11")
+        #endif
+    }
+
     /// Structural recomposition through the bridge: toggling native `@State` must insert
     /// and remove a node from the Compose tree, not just update values.
     func testConditionalContentTogglesExistence() throws {


### PR DESCRIPTION
## Summary
- Bridges `ToggleStyle` following the `ButtonStyle` bridge pattern: an `identifier` for built-in styles, `ToggleStyleConfiguration` wrapping the bridged Java configuration with a real `@Binding isOn`, and `toggleStyle(_:)` resolving custom styles through `ResolvedToggleStyle` instead of returning `self` unchanged
- Fixes a redundant `View` conformance on `ToggleStyleConfiguration.Label`

## Dependency
This branch is stacked directly on top of `feature/button-style-protocol`, which adds the `ButtonStyle`/`PrimitiveButtonStyle` bridge that this PR's `ToggleStyle` work mirrors. That branch has not yet been opened as a PR against this upstream repo, so this diff currently includes those button-style bridge commits as well.

**Please do not merge this PR until the button-style-protocol changes have landed in this repo's `main` first.** Once they do, this diff will narrow to just the toggle-style-specific commits.

## Test plan
- [ ] Build for the SKIP (Android/Compose) target
- [ ] Build for the Darwin target
- [ ] Verify a custom `ToggleStyle` bridges and renders correctly on both platforms